### PR TITLE
feat: 104 cap edit add area

### DIFF
--- a/backend/alembic/data/cap_statuses.json
+++ b/backend/alembic/data/cap_statuses.json
@@ -1,7 +1,7 @@
 [
     {
         "id": 1,
-        "cap_event_status": "CREATE"
+        "cap_event_status": "ALERT"
     },
     {
         "id": 2,

--- a/backend/alembic/versions/V11_fix_alert_status_table.py
+++ b/backend/alembic/versions/V11_fix_alert_status_table.py
@@ -36,6 +36,10 @@ def update(old_value, new_value):
     session = sqlmodel.Session(bind=bind)
 
     query = sqlmodel.select(cap_model.Cap_Event_Status).where(cap_model.Cap_Event_Status.cap_event_status==old_value)
-    record = session.exec(query).one()
-    record.cap_event_status = new_value
-    session.commit()
+    record = session.exec(query).all()
+    if len(record) > 1:
+        raise ValueError(f"multiple records found for {old_value}, only one expected")
+    elif len(record) == 1:
+        record = record[0]
+        record.cap_event_status = new_value
+        session.commit()

--- a/backend/alembic/versions/V11_fix_alert_status_table.py
+++ b/backend/alembic/versions/V11_fix_alert_status_table.py
@@ -1,0 +1,41 @@
+"""fix alert status table
+
+Revision ID: V11
+Revises: V10
+Create Date: 2024-05-15 10:21:06.351463
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+import src.v1.models.cap as cap_model
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'V11'
+down_revision: Union[str, None] = 'V10'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+from_to_values = ['CREATE', 'ALERT']
+
+
+def upgrade() -> None:
+    old_value = from_to_values[0]
+    new_value = from_to_values[1]
+    update(old_value, new_value)
+
+def downgrade() -> None:
+    old_value = from_to_values[1]
+    new_value = from_to_values[0]
+    update(old_value, new_value)
+
+def update(old_value, new_value):
+    bind = op.get_bind()
+    session = sqlmodel.Session(bind=bind)
+
+    query = sqlmodel.select(cap_model.Cap_Event_Status).where(cap_model.Cap_Event_Status.cap_event_status==old_value)
+    record = session.exec(query).one()
+    record.cap_event_status = new_value
+    session.commit()

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -516,6 +516,20 @@ dnspython = ">=2.0.0"
 idna = ">=2.0.0"
 
 [[package]]
+name = "faker"
+version = "25.2.0"
+description = "Faker is a Python package that generates fake data for you."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "Faker-25.2.0-py3-none-any.whl", hash = "sha256:cfe97c4857c4c36ee32ea4aaabef884895992e209bae4cbd26807cf3e05c6918"},
+    {file = "Faker-25.2.0.tar.gz", hash = "sha256:45b84f47ff1ef86e3d1a8d11583ca871ecf6730fad0660edadc02576583a2423"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.4"
+
+[[package]]
 name = "fastapi"
 version = "0.111.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -1584,6 +1598,20 @@ pytest = ">=2.6.4"
 watchdog = ">=0.6.0"
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -2488,4 +2516,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "b0cdf3a69f548f9e7af097486eeedc290f6f18bfd36df422dfe57bcbf1d65d40"
+content-hash = "a6c748ce3b1a5954eef877fbf7e1cb79e511d65bdd71cf8e0b5565faf766c5ef"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,7 +21,7 @@ httpx = "^0.27.0"
 ruff = "^0.4.0"
 pytest-env = "^1.1.3"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 prospector = "^1.10.3"
 pytest = "^8.1.1"
 pytest-cov = "^5.0.0"
@@ -29,9 +29,7 @@ pytest-watch = "^4.2.0"
 alembic = "^1.13.1"
 black = "^24.3.0"
 isort = "^5.13.2"
-
-[tool.poetry.group.dev.dependencies]
-pytest = "^8.1.1"
+faker = "^25.2.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -81,8 +81,6 @@ app.include_router(alert_routes, prefix=api_prefix_v1 + "/alerts", tags=["Alerts
 app.include_router(alert_levels_router, prefix=api_prefix_v1 + "/alert_levels", tags=["Alert Levels"])
 app.include_router(cap_router, prefix=api_prefix_v1 + "/cap", tags=["Common Alerting Protocol Events"])
 
-
-
 # Define the filter
 class EndpointFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:

--- a/backend/src/v1/crud/crud_alerts.py
+++ b/backend/src/v1/crud/crud_alerts.py
@@ -87,6 +87,8 @@ def convert_to_alert(
     :param alert: the input alert object
     :type alert: alerts_models.Alert_Basins_Write
     """
+    LOGGER.debug(f"session type: {type(session)}, {type(session)}")
+
     alert_write: alerts_models.Alerts = alerts_models.Alerts(
         alert_description=alert.alert_description,
         alert_hydro_conditions=alert.alert_hydro_conditions,
@@ -99,7 +101,9 @@ def convert_to_alert(
         basin_sql = select(basins_model.Basins).where(
             basins_model.Basins.basin_name == alert_area_level.basin.basin_name
         )
-        basin = session.exec(basin_sql).first()
+        LOGGER.debug(f"basin_sql: {basin_sql}, {session}, {alert_area_level.basin.basin_name}")
+        results = session.exec(basin_sql)
+        basin = results.first()
 
         # get the alert level object
         alert_lvl_sql = select(alerts_models.Alert_Levels).where(

--- a/backend/src/v1/crud/crud_alerts.py
+++ b/backend/src/v1/crud/crud_alerts.py
@@ -46,10 +46,13 @@ def create_alert_with_basins_and_level(
         )
         basin_data = session.exec(basin_query).one()
 
-        alert_level_select = select(alerts_models.Alert_Levels).where(
-            alerts_models.Alert_Levels.alert_level == basin_level["alert_level"]
-        )
-        alert_level_data = session.exec(alert_level_select).one()
+        # alert_level_select = select(alerts_models.Alert_Levels).where(
+        #     alerts_models.Alert_Levels.alert_level == basin_level["alert_level"]
+        # )
+        # alert_level_data = session.exec(alert_level_select).one()
+        alert_level_data = get_alert_level(session=session, 
+                                           alert_lvl_str=basin_level["alert_level"])
+
 
         junction_table = alerts_models.Alert_Areas(
             alert=alert,
@@ -107,11 +110,14 @@ def convert_to_alert(
         basin = results.first()
 
         # get the alert level object
-        alert_lvl_sql = select(alerts_models.Alert_Levels).where(
-            alerts_models.Alert_Levels.alert_level
-            == alert_area_level.alert_level.alert_level
-        )
-        alert_lvl = session.exec(alert_lvl_sql).first()
+        # alert_lvl_sql = select(alerts_models.Alert_Levels).where(
+        #     alerts_models.Alert_Levels.alert_level
+        #     == alert_area_level.alert_level.alert_level
+        # )
+        # alert_lvl = session.exec(alert_lvl_sql).first()
+        alert_lvl = get_alert_level(
+            session=session,
+            alert_lvl_str=alert_area_level.alert_level.alert_level)
 
         LOGGER.debug(f"basin: {basin}")
         LOGGER.debug(f"alert level: {alert_lvl}")
@@ -330,6 +336,7 @@ def update_alert(
 
         current_alert.alert_updated = datetime.datetime.now(datetime.timezone.utc)
         # ---- Alert record update complete
+    
     LOGGER.debug(f"current alert before send: {current_alert}")
     return current_alert
 
@@ -536,3 +543,11 @@ def get_alert_levels(session: Session) -> list[alerts_models.Alert_Levels]:
     alert_levels = session.exec(select(alerts_models.Alert_Levels)).all()
     LOGGER.debug(f"alert_levels: {alert_levels}")
     return alert_levels
+
+
+def get_alert_level(session: Session, alert_lvl_str: str) -> alerts_models.Alert_Levels:
+    alert_lvl_sql = select(alerts_models.Alert_Levels).where(
+        alerts_models.Alert_Levels.alert_level == alert_lvl_str
+    )
+    alert_lvl = session.exec(alert_lvl_sql).first()
+    return alert_lvl

--- a/backend/src/v1/crud/crud_alerts.py
+++ b/backend/src/v1/crud/crud_alerts.py
@@ -6,6 +6,7 @@ from sqlmodel import Session, select
 
 import src.db.session
 import src.types
+import src.v1.crud.crud_cap as crud_cap
 import src.v1.models.alerts as alerts_models
 import src.v1.models.basins as basins_model
 
@@ -327,17 +328,8 @@ def update_alert(
             current_alert.alert_links.append(alert_area)
             session.refresh(current_alert)
 
-        # finally deal with deletes
-        # identify records in basin_levels_existing that do not exist in basin_levels_incomming
-        # and delete those records
-        # for existing_record in basin_levels_existing:
-        #     if not in basin_levels_incomming:
-        #         # delete the record
-        #         LOGGER.info(f"deleting the record: {existing_record}")
-
-        current_alert.alert_updated = datetime.datetime.utcnow()
-        # don't think I need to add the session
-        # session.add(current_alert)
+        current_alert.alert_updated = datetime.datetime.now(datetime.timezone.utc)
+        # ---- Alert record update complete
     LOGGER.debug(f"current alert before send: {current_alert}")
     return current_alert
 

--- a/backend/src/v1/crud/crud_cap.py
+++ b/backend/src/v1/crud/crud_cap.py
@@ -105,3 +105,22 @@ def get_cap_events(session: Session):
     #LOGGER.debug(f"cap_events: {cap_events}")
     return cap_events
 
+def update_cap_event(session: Session, alert: alerts_models.Alerts):
+    """
+    This method will handle the various operations that need to take place when
+    an alert is edited.  
+
+    The method will determine the following categories for what has changed and
+    actions for the cap alerts when these changes take place:
+
+    * new area added to alert with same alert level
+    * new area added to alert with different alert level
+
+    See docs/
+    
+    :param session: _description_
+    :type session: Session
+    :param alert: _description_
+    :type alert: alerts_models.Alerts
+    """
+    pass

--- a/backend/src/v1/crud/crud_cap.py
+++ b/backend/src/v1/crud/crud_cap.py
@@ -372,11 +372,6 @@ def __write_history_for_cap_comp(
         # the update cap comp object
         cur_cap_event = __get_cap_event(caps_for_alert, update.alert_level.alert_level)
 
-        # create a list of the basins that are in the new cap event
-        # basin_list = []
-        # for basin in cur_cap_event.event_areas:
-        #     basin_list.append(basins_models.Basins(basin_name=basin.cap_area_basin.basin_name))
-
         # creating the history record
         cap_event_history = cap_models.Cap_Event_History(
             alert_id=alert_id,

--- a/backend/src/v1/crud/crud_cap.py
+++ b/backend/src/v1/crud/crud_cap.py
@@ -11,8 +11,6 @@ import src.v1.models.cap as cap_models
 LOGGER = logging.getLogger(__name__)
 
 
-
-
 def get_cap_event_status(session: Session, status: str):
     """
     queries the cap event status lookup table for the record that corresponds
@@ -206,8 +204,11 @@ def record_history(session: Session, alert: alerts_models.Alerts):
     * new cap events are ignored as they are new and therfor do not require a history
       record
 
-    :param session: _description_
+    :param session: the current database session / transaction
     :type session: Session
+    :param alert: the new modified alert, this alert can be compared with the alert
+        that currently exists in the database
+    :type alert: alerts_models.Alerts
     """
     # retrieve the caps associated with the incomming alert, need this later to figure
     # out attributes from the actual cap event, for the history records

--- a/backend/src/v1/crud/crud_cap.py
+++ b/backend/src/v1/crud/crud_cap.py
@@ -1,12 +1,41 @@
 import datetime
 import logging
+from typing import List
 
 from sqlmodel import Session, select
 
 import src.v1.models.alerts as alerts_models
+import src.v1.models.basins as basins_models
 import src.v1.models.cap as cap_models
 
 LOGGER = logging.getLogger(__name__)
+
+
+
+
+def get_cap_event_status(session: Session, status: str):
+    """
+    queries the cap event status lookup table for the record that corresponds
+    with the supplied status string
+
+    :param session: database sqlmodel session
+    :type session: sqlmodel.Session
+    :param status: the status value for the record we want to retrieve
+    :type status: str
+    :raises LookupError: error when status supplied cannot be found in the database
+    :return: a cap event status record for the status that was queried
+    :rtype: cap_models.Cap_Event_Status
+    """
+    select_cap_status = select(cap_models.Cap_Event_Status).where(cap_models.Cap_Event_Status.cap_event_status==status)
+    LOGGER.debug(f"select_cap_status: {select_cap_status}")
+    cap_status_create_record = session.exec(select_cap_status).first()
+    if not cap_status_create_record:
+        msg = (
+            f"trying to retrieve the record for status={status}, however there" +
+              " is no record with that value in the database.")
+        raise LookupError(msg)
+    LOGGER.debug(f"cap_status_create_record: {cap_status_create_record}")
+    return cap_status_create_record
 
 def create_cap_event(session: Session,
                      alert: alerts_models.Alerts):
@@ -28,11 +57,7 @@ def create_cap_event(session: Session,
     # get the cap_status record for create
     # todo: should create an enum that reads the lookup table or something like that try to make this
     # a safer more consistent query.
-    select_cap_status = select(cap_models.Cap_Event_Status).where(cap_models.Cap_Event_Status.cap_event_status=='ALERT')
-    LOGGER.debug(f"select_cap_status: {select_cap_status}")
-    cap_status_create_record = session.exec(select_cap_status).first()
-    LOGGER.debug(f"cap_status_create_record: {cap_status_create_record}")
-
+    cap_status_create_record = get_cap_event_status(session, 'ALERT')
 
     for alert_link in alert.alert_links:
         LOGGER.debug(f"alert_link to create cap: {alert_link}")
@@ -74,10 +99,11 @@ def create_cap_event(session: Session,
             cap_event = alert_levels_created[alert_link.alert_level.alert_level]
             cap_event.event_areas.append(cap_event_area)
             
-            # add the basin to the cap_event
-            pass
     session.add(cap_event)
     return alert_levels_created.values()
+
+
+
     
 def get_cap_events_for_alert(session: Session, alert_id: int):
     """
@@ -88,7 +114,7 @@ def get_cap_events_for_alert(session: Session, alert_id: int):
     :param alert_id: the alert id
     :type alert_id: int
     """
-    LOGGER.debug(f"getting the cap event for alert id: {alert_id}")
+    LOGGER.debug(f"getting the cap events for alert id: {alert_id}")
     cap_event = session.exec(select(cap_models.Cap_Event).where(
         cap_models.Cap_Event.alert_id == alert_id)).all()
     return cap_event
@@ -109,19 +135,447 @@ def get_cap_events(session: Session):
 def update_cap_event(session: Session, alert: alerts_models.Alerts):
     """
     This method will handle the various operations that need to take place when
-    an alert is edited.  
+    an alert is edited. 
 
-    The method will determine the following categories for what has changed and
-    actions for the cap alerts when these changes take place:
-
-    * new area added to alert with same alert level
-    * new area added to alert with different alert level
+    Steps taken:
+        - calculate the cap events for the input alert
+        - query for existing cap events in the database for the current alert
+        - calculate the differences between the two sets of caps and determine
+            which caps need to be updated and how
+        - write existing state of caps that are to be changed to the cap history
+            tables
+        - write updates to the caps that have changed
 
     See docs/
     
-    :param session: _description_
-    :type session: Session
-    :param alert: _description_
+    :param session: input database session
+    :type session: sqlmodel.Session
+    :param alert: The updated state to an alert object
     :type alert: alerts_models.Alerts
     """
-    pass
+    # 1. generate caps for the current the alert
+
+    # caps = get_cap_events_for_alert(session, alert_id: int):
+    #existing_caps = get_cap_events_for_alert(session, alert.alert_id)
+    cap_comp = CapCompare(session, alert)
+    cap_delta = cap_comp.get_delta()
+
+    # from the delta we can retrieve the CREATE / UPDATE / CANCEL caps
+    creates = cap_delta.getCreates()
+    updates = cap_delta.getUpdates()
+    cancels = cap_delta.getCancels()
+
+    # only write history records if there are changes
+    if creates or updates or cancels:
+        record_history(session, alert)
+
+
+    LOGGER.debug(f"creates: {creates}")
+    LOGGER.debug(f"updates: {updates}")
+    LOGGER.debug(f"cancels: {cancels}")
+
+    # write the history record
+    record_history(session, alert)
+
+        
+
+
+    #generate_caps_struct(session, alert)
+    # 2. compare generated caps against existing caps identify diffs
+    
+
+    # 3. record the diffs to 
+    # 3. determine what the changes are:
+    #    - new area added to alert UPDATE 
+    #    - new area new alert level ALERT/UPDATE
+    #    - ...
+    #
+    # 4. before changes are made cache existing record to history
+    LOGGER.debug(f"alert: {alert}")
+
+def record_history(session: Session, alert: alerts_models.Alerts):
+    """
+    This method will write the history records for the cap events that are going
+    to be updated.  The history records will be written to the cap_event_history.
+
+    the method does the following in order to write the history:
+    * extracts the alert_id
+    * compares the existing cap events in the database with the incomming alert
+        and determines what has changed
+    * changes are categorized into updates and cancels.
+    * new cap events are ignored as they are new and therfor do not require a history
+      record
+
+    :param session: _description_
+    :type session: Session
+    """
+    # retrieve the caps associated with the incomming alert, need this later to figure
+    # out attributes from the actual cap event, for the history records
+    cap_events = get_cap_events_for_alert(session, alert.alert_id)
+    LOGGER.debug(f"cap_events: {cap_events}")
+
+    # looks at the existing alert in the database and compare with the incomming
+    # alert to identify how the caps should be updated
+    cap_comp = CapCompare(session=session, alert_incomming=alert)
+    cap_delta = cap_comp.get_delta()
+    updates = cap_delta.getUpdates()
+    cancels = cap_delta.getCancels()
+
+    __write_history_for_cap_comp(
+        session=session,
+        cap_comps=updates,
+        caps_for_alert=cap_events,
+        alert_id=alert.alert_id)
+    
+    __write_history_for_cap_comp(
+        session=session,
+        cap_comps=cancels,
+        caps_for_alert=cap_events,
+        alert_id=alert.alert_id)
+        
+def __write_history_for_cap_comp(
+        session: Session, 
+        cap_comps: cap_models.Cap_Comparison, 
+        caps_for_alert: List[cap_models.Cap_Event], 
+        alert_id: int):
+    """
+    writes a history record for a cap comparison object
+
+    :param session: input database session
+    :type session: sqlmodel.Session
+    :param cap_comps: a list of cap comparison objects that are used to 
+    """
+    # write a history record for each cap event that is going to be updated
+    for update in cap_comps:
+        # extracts the cap event that is associated with the current alert level in 
+        # the update cap comp object
+        cur_cap_event = __get_cap_event(caps_for_alert, update.alert_level.alert_level)
+
+        # create a list of the basins that are in the new cap event
+        basin_list = []
+        for basin in cur_cap_event.event_areas:
+            basin_list.append(basins_models.Basins(basin_name=basin.cap_area_basin.basin_name))
+
+        # creating the history record
+        cap_event_history = cap_models.Cap_Event_History(
+            alert_id=alert_id,
+            cap_event_id=cur_cap_event.cap_event_id,
+            cap_event_updated_date=cur_cap_event.cap_event_updated_date,
+            cap_event_hist_created_date=datetime.datetime.now(datetime.timezone.utc),
+            alert_level=cur_cap_event.alert_level.alert_level_id,
+            cap_event_status_id=cur_cap_event.cap_event_status.cap_event_status_id,
+        )
+        session.add(cap_event_history)
+        session.flush()
+
+        # now create the basin relationships
+        for basin in cur_cap_event.event_areas:
+            LOGGER.debug(f"basin: {basin}")
+            cap_event_area_hist = cap_models.Cap_Event_Areas_History(
+                cap_event_history_id=cap_event_history.cap_event_history_id,
+                basin_id=basin.basin_id
+            )
+            session.add(cap_event_area_hist)
+            LOGGER.debug(f"cap_event_area_hist: {cap_event_area_hist}")
+        session.flush()
+
+    
+
+def __get_cap_event(cap_events: List[cap_models.Cap_Event], alert_level: str):
+    """
+    gets a list of cap events, searches those cap events for the event that has
+    the specified alert level and returns that event
+
+    :param cap_events: a list of cap events
+    :type cap_events: List[cap_models.Cap_Event]
+    :param alert_level: the alert level for the cap event that we want to extract
+    :type alert_level: str
+    """
+    for cap_event in cap_events:
+        if cap_event.alert_level.alert_level == alert_level:
+            return cap_event
+    return None
+
+
+class CapCompare():
+    """
+    a class that allows for the comparison of cap events.  Doesn't store the cap
+    event types, those will get calculated later when the cap actually gets 
+    updated, but instead focuses on the the following attributes:
+
+        * related alert id
+        * alert level
+        * areas impacted by the alert
+    """
+    def __init__(self, session: Session, alert_incomming: alerts_models.Alerts):
+        self.session = session
+        self.alert = alert_incomming
+        # ensures the input alert relationships through sqlmodel work. Without
+        # this wind up with a valid basin_id but when request the data get None
+        session.flush()
+
+        self.new_alert_cap_comp = None
+        self.existing_alert_cap_comp = None
+
+        self.generate_incomming_cap_comp_from_alert()
+        self.generate_existing_cap_comp_from_alert()
+
+    def generate_incomming_cap_comp_from_alert(self) -> List[cap_models.Cap_Comparison]:
+        """
+        generates a list of cap comparison objects that can be used to compare
+        existing vs future state of cap events, determine what needs to be written
+        to history, what caps need to updated.
+
+        :param alert: input alert object containing the new alert state.
+        :type alert: 
+        """
+        levels = {} # used to keep track of which events are associated with what alert level
+        for alert_level_area in self.alert.alert_links:
+            #basin = alert_level_area.basin
+            LOGGER.debug(f"alert_level_area: {alert_level_area}")
+            LOGGER.debug(f"alert_level_area.basin: {alert_level_area.basin}")
+            LOGGER.debug(f"basin_name: {alert_level_area.basin.basin_name}")
+            basinBase = basins_models.BasinBase(basin_name=alert_level_area.basin.basin_name)
+
+            current_level_str = alert_level_area.alert_level.alert_level
+            LOGGER.debug(f"alert_level: {current_level_str} basin: {alert_level_area.basin}")
+            if current_level_str not in levels:
+                alert_lvl = alerts_models.Alert_Levels_Base(alert_level=current_level_str)
+                levels[current_level_str] = cap_models.Cap_Comparison(alert_level=alert_lvl, basins=[basinBase])
+            else:
+                levels[current_level_str].basins.append(basinBase)
+        LOGGER.debug(f"levels: {levels}")
+        self.new_alert_cap_comp = levels.values()
+
+    def generate_existing_cap_comp_from_alert(self) -> List[cap_models.Cap_Comparison]:
+        """
+        Using the alert_id in the alert object will query the database for the 
+        existing caps associated with that alert, and structure the data for 
+        those caps into a cap comparison object
+        """
+        # query for existing caps.
+        query = select(cap_models.Cap_Event).where(cap_models.Cap_Event.alert_id==self.alert.alert_id)
+        results = self.session.exec(query).all()
+        levels = {} # used to keep track of which events are associated with what alert level
+
+        for cap in results:
+            LOGGER.debug(f"cap: {cap}")
+            alert_lvl_base = alerts_models.Alert_Levels_Base(alert_level=cap.alert_level.alert_level)
+            for area_link in cap.event_areas:
+                basinBase = basins_models.BasinBase(basin_name=area_link.cap_area_basin.basin_name)
+                if alert_lvl_base.alert_level not in levels:
+                    levels[cap.alert_level.alert_level] = cap_models.Cap_Comparison(alert_level=alert_lvl_base, basins=[basinBase])
+                else:
+                    levels[cap.alert_level.alert_level].basins.append(basinBase)
+        self.existing_alert_cap_comp = levels.values()
+
+    def get_delta(self):
+        """
+        Calculates the differences between the existing cap events and the cap 
+        events that are associated with the current state of the alert.
+
+        Returns a delta object.  The delta object contains information about 
+        how the caps should be updated.
+
+        * CREATE - a new alert level has been created that didn't previously exist
+                   for this alert
+        * UPDATE - an area has been added or removed from the alert
+        * CANCEL - All areas associated with the alert have been removed
+
+        The delta object will have methods that provide this information, exammple
+        * getCreates()
+        * getUpdates()
+        * getCancels()
+
+        For more info see the docs on the CapDelta class.
+        """
+        return CapDelta(self.existing_alert_cap_comp, self.new_alert_cap_comp)
+
+
+class CapDelta:
+    def __init__(self, 
+                 existing_cap_struct: List[cap_models.Cap_Comparison], 
+                 new_cap_struct: List[cap_models.Cap_Comparison]):
+        self.existing_cap_struct = existing_cap_struct
+        self.new_cap_struct = new_cap_struct
+        self.deltas = [] # records the level in here so we know later which levels have changed
+        self.__calcDeltas()
+
+    def __calcDeltas(self):
+        """
+        Adds the alert level string to the self.deltas list if a an alert level exists 
+        in either existing or new cap structs, but not in both.
+        """
+        # identify caps in self.new_cap_struct and not in self.existing_cap_struct
+        for existing_cap in self.existing_cap_struct:
+            if existing_cap in self.new_cap_struct:
+                # identifies that existing_cap exists in self.new_cap_struct 
+                # which identifies that it has not changed.
+                LOGGER.debug(f"cap in both: {existing_cap}")
+            else:
+                # identifies something is different
+                LOGGER.debug("cap not in both:")
+                self.log_cap(existing_cap) # utility to log whats going on
+                LOGGER.debug("\ncomparison cap...")
+                self.deltas.append(existing_cap.alert_level.alert_level)
+        for new_cap in self.new_cap_struct:
+            if new_cap in self.existing_cap_struct:
+                LOGGER.debug(f"cap in both: {existing_cap}")
+            else:
+                # in new and not in existing
+                LOGGER.debug("cap in new, but not existing")
+                self.log_cap(new_cap)
+                if new_cap.alert_level.alert_level not in self.deltas:
+                    self.deltas.append(new_cap.alert_level.alert_level)
+        LOGGER.debug(f"deltas: {self.deltas}")
+
+    def __get_cap_comp_dict(self, cap_comp: List[cap_models.Cap_Comparison]):
+        """
+        returns a dictionary representing the List of cap comparison objects where 
+        the alert level is the key for the 
+
+        :param cap_comp: _description_
+        :type cap_comp: _type_
+        """
+        cap_lvl_dict = {}
+        for new_cap in cap_comp:
+            cap_lvl_dict[new_cap.alert_level.alert_level] = new_cap
+        return cap_lvl_dict
+
+    def log_cap(self, cap_struct: cap_models.Cap_Comparison):
+        """
+        mostly for debugging... prints the alert_level for the input cap
+        and the basins associated with it.
+
+        :param cap_struct: _description_
+        :type cap_struct: _type_
+        """
+        LOGGER.debug(f"level: {cap_struct.alert_level.alert_level}")
+        for basin in cap_struct.basins:
+            LOGGER.debug(f"    basin: {basin.basin_name}")
+
+    def getCreates(self):
+        """
+        returns a list of objects to send to create_cap_event method
+
+        creates are identified by alert levels that are in the new_cap_struct and 
+        not in the existing_cap_struct.
+        """
+        cap_creates = []
+
+        # create a dict of caps, indexed by their alert levels.
+        existing_cap_lvl_dict = self.__get_cap_comp_dict(self.existing_cap_struct)
+        new_cap_lvl_dict = self.__get_cap_comp_dict(self.new_cap_struct)
+
+        if self.deltas:
+            # creates are identified by alert levels that are in the new_cap_struct
+            for alert_level in self.deltas:
+                if alert_level not in existing_cap_lvl_dict:
+                    cap_creates.append(new_cap_lvl_dict[alert_level])
+        return cap_creates
+
+    def getUpdates(self):
+        """
+        returns a list of objects to sent to update_cap_event method
+
+        updates are identified by alert levels that are in both the new_cap_struct
+        and the existing_cap_struct, but have different basins associated with them.
+
+        What gets returned is a list of objects that define the changes that 
+        have been detected between the existing and new state of the cap
+        """
+        existing_cap_lvl_dict = self.__get_cap_comp_dict(self.existing_cap_struct)
+        new_cap_lvl_dict = self.__get_cap_comp_dict(self.new_cap_struct)
+
+        # updates are issued when the alert level is the same in existing and 
+        # new cap structs, but the basins are different
+
+        # the updates struct will return the new state of the cap event with either
+        # added basins or removed basins
+        updates = []
+
+        if self.deltas:
+            for alert_level in self.deltas:
+                # alert level must exist in both structs
+                if alert_level in existing_cap_lvl_dict and alert_level in new_cap_lvl_dict:
+                    existing_cap = existing_cap_lvl_dict[alert_level]
+                    new_cap = new_cap_lvl_dict[alert_level]
+                    LOGGER.debug(f"existing cap: {existing_cap}")
+                    LOGGER.debug(f"new cap: {new_cap}")
+
+                    if existing_cap.basins != new_cap.basins:
+                        # the alert level is the same, but the basins are different
+                        # so we need to update the cap event
+                        existing_basin_names = []
+                        for basin in existing_cap.basins:
+                            existing_basin_names.append(basin.basin_name)
+                        new_basin_names = []
+                        for basin in new_cap.basins:
+                            new_basin_names.append(basin.basin_name)
+                            
+                        LOGGER.debug(f"basins are not equal! existing: {existing_basin_names}, new: {new_basin_names}")
+                        updates.append(new_cap)
+        return updates
+
+    def getCancels(self):
+        """
+        returns a list of objects to send to cancel_cap_event method.
+
+        cancels are identified by alert levels that are in the existing_cap_struct
+        and not in the new_cap_struct.
+        """
+        cap_cancels = []
+
+        # create a dict of caps, indexed by their alert levels.
+        existing_cap_lvl_dict = self.__get_cap_comp_dict(self.existing_cap_struct)
+        new_cap_lvl_dict = self.__get_cap_comp_dict(self.new_cap_struct)
+
+        LOGGER.debug(f"differences: {self.deltas}")
+        if self.deltas:
+            LOGGER.debug("deltas exist")
+            # creates are identified by alert levels that are in the new_cap_struct
+            for alert_level in self.deltas:
+                if alert_level not in new_cap_lvl_dict:
+                    cap_cancels.append(existing_cap_lvl_dict[alert_level])
+                    # LOGGER.debug("")
+        return cap_cancels
+
+    def is_cap_comp_equal(self, cap_comp1: List[cap_models.Cap_Comparison], cap_comp2: List[cap_models.Cap_Comparison]):
+        """
+        compares two lists of cap comparison objects to determine if they are equal
+        """
+        equal = True
+        if len(cap_comp1) != len(cap_comp2):
+            equal = False
+        else:
+            # organize by alert level
+            cap_comp1_dict = {}
+            for cap in cap_comp1:
+                basins = []
+                for basin in cap.basins:
+                    basins.append(basin.basin_name)
+                basins.sort()
+                cap_comp1_dict[cap.alert_level.alert_level] = basins
+                
+            cap_comp2_dict = {}
+            for cap in cap_comp2:
+                basins = []
+                for basin in cap.basins:
+                    basins.append(basin.basin_name)
+                basins.sort()
+                cap_comp2_dict[cap.alert_level.alert_level] = basins
+
+            # ensure each struct has the same alert levels
+            alert_lvls_1 = list(cap_comp1_dict.keys())
+            alert_lvls_1.sort()
+            alert_lvls_2 = list(cap_comp2_dict.keys())
+            alert_lvls_2.sort()
+            if alert_lvls_1 != alert_lvls_2:
+                equal = False
+
+            if equal:
+                # now make sure for each alert level they have the same basins
+                for lvl in alert_lvls_1:
+                    if cap_comp1_dict[lvl] != cap_comp2_dict[lvl]:
+                        equal = False
+        return equal

--- a/backend/src/v1/crud/crud_cap.py
+++ b/backend/src/v1/crud/crud_cap.py
@@ -26,8 +26,9 @@ def create_cap_event(session: Session,
     alert_levels_created = {}
 
     # get the cap_status record for create
-    # cap_models.Cap_Event_Status(cap_event_status='CREATE'),
-    select_cap_status = select(cap_models.Cap_Event_Status).where(cap_models.Cap_Event_Status.cap_event_status=='CREATE')
+    # todo: should create an enum that reads the lookup table or something like that try to make this
+    # a safer more consistent query.
+    select_cap_status = select(cap_models.Cap_Event_Status).where(cap_models.Cap_Event_Status.cap_event_status=='ALERT')
     LOGGER.debug(f"select_cap_status: {select_cap_status}")
     cap_status_create_record = session.exec(select_cap_status).first()
     LOGGER.debug(f"cap_status_create_record: {cap_status_create_record}")

--- a/backend/src/v1/models/alerts.py
+++ b/backend/src/v1/models/alerts.py
@@ -37,11 +37,17 @@ class AlertsRead(AlertsBase):
 
     alert_id: Optional[int] = Field(default=None, primary_key=True)
     alert_created: datetime.datetime = Field(
-        default_factory=datetime.datetime.utcnow, nullable=False
+        default_factory=lambda: datetime.datetime.now(datetime.timezone.utc), nullable=False
     )
     alert_updated: datetime.datetime = Field(
-        default_factory=datetime.datetime.utcnow, nullable=False
+        default_factory=lambda: datetime.datetime.now(datetime.timezone.utc), nullable=False
     )
+    # alert_created: datetime.datetime = Field(
+    #     default_factory=datetime.datetime.utcnow, nullable=False
+    # )
+    # alert_updated: datetime.datetime = Field(
+    #     default_factory=datetime.datetime.utcnow, nullable=False
+    # )
 
 class Alert_Areas_Read(SQLModel):
     alert_id: int = Field(
@@ -204,7 +210,8 @@ class Alert_Area_History(SQLModel, table=True):
     alert_history: "Alert_History" = Relationship(back_populates="alert_history_links")
 
 
-from .cap import Cap_Event_And_Areas, Cap_Event_History  # noqa: E402
+from .cap import Cap_Comparison, Cap_Event_And_Areas, Cap_Event_History  # noqa: E402
 
 Cap_Event_And_Areas.model_rebuild()
 Cap_Event_History.model_rebuild()
+Cap_Comparison.model_rebuild()

--- a/backend/src/v1/models/cap.py
+++ b/backend/src/v1/models/cap.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TYPE_CHECKING, List, Optional, Required
+from typing import TYPE_CHECKING, List, Optional, Required, Self
 
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -8,8 +8,8 @@ from src.v1.models.basins import Basins
 
 # from src.v1.models.alerts as alert_models
 if TYPE_CHECKING:
-    from src.v1.models.alerts import Alert_Levels, Alert_Levels_Read
-
+    from src.v1.model.basins import BasinBase
+    from src.v1.models.alerts import Alert_Levels, Alert_Levels_Base, Alert_Levels_Read
 default_schema = Settings.DEFAULT_SCHEMA
 
 
@@ -145,3 +145,13 @@ class Cap_Event_Status(SQLModel, table=True):
     # cap_event_status
     cap_event_status_lnk: Optional["Cap_Event"] = Relationship(back_populates="cap_event_status")
     cap_event_hist_status_lnk: Optional["Cap_Event_History"] = Relationship(back_populates="cap_event_status")
+
+
+class Cap_Comparison(SQLModel):
+    """ 
+    a model used to compare calculated (future) caps vs existing caps.  Only 
+    need to look at what the alert level is, and the associated areas.
+    """
+    alert_level: "Alert_Levels_Base" = ...
+    basins: List["BasinBase"]
+    cap_event_id: Optional[int] = None

--- a/backend/src/v1/models/cap.py
+++ b/backend/src/v1/models/cap.py
@@ -35,7 +35,6 @@ class Cap_Event_Base(SQLModel):
         default_factory=datetime.datetime.utcnow, nullable=False
     )
 
-
 class Cap_Event_Read(Cap_Event_Base):
     cap_event_id: int = Field(default=None, primary_key=True)
 
@@ -58,7 +57,6 @@ class Cap_Event(Cap_Event_Read, table=True):
     event_areas: List["Cap_Event_Areas"] = Relationship(back_populates="event_links")
     alert_level: "Alert_Levels" = Relationship(back_populates="cap_link")
     cap_event_status: Optional["Cap_Event_Status"] = Relationship(back_populates="cap_event_status_lnk")
-
 
 class Cap_Event_Areas_Base(SQLModel):
     cap_event_area_id: int = Field(default=None, primary_key=True)
@@ -146,7 +144,6 @@ class Cap_Event_Status(SQLModel, table=True):
     cap_event_status_lnk: Optional["Cap_Event"] = Relationship(back_populates="cap_event_status")
     cap_event_hist_status_lnk: Optional["Cap_Event_History"] = Relationship(back_populates="cap_event_status")
 
-
 class Cap_Comparison(SQLModel):
     """ 
     a model used to compare calculated (future) caps vs existing caps.  Only 
@@ -154,4 +151,4 @@ class Cap_Comparison(SQLModel):
     """
     alert_level: "Alert_Levels_Base" = ...
     basins: List["BasinBase"]
-    cap_event_id: Optional[int] = None
+    # cap_event_id: Optional[int] = None

--- a/backend/src/v1/routes/alert_routes.py
+++ b/backend/src/v1/routes/alert_routes.py
@@ -130,7 +130,10 @@ def update_alert(
     updated_alert.author_name = token['display_name']
     session.add(updated_alert)
 
-    # now handle the cap emissions
+    
+    # write cap history
+    crud_cap.record_history(session, updated_alert)
+    # update cap events
     crud_cap.update_cap_event(session, updated_alert)
     return updated_alert
 

--- a/backend/src/v1/routes/alert_routes.py
+++ b/backend/src/v1/routes/alert_routes.py
@@ -119,7 +119,8 @@ def update_alert(
 
     # write history
     
-
+    # need to write the alert history here
+    #  TODO: --- ALERT HISTORY OPERATION goes here
 
     updated_alert = crud_alerts.update_alert(
         session=session, alert_id=alert_id, updated_alert=alert

--- a/backend/src/v1/routes/alert_routes.py
+++ b/backend/src/v1/routes/alert_routes.py
@@ -126,6 +126,9 @@ def update_alert(
     LOGGER.debug(f"token: {token}")
     updated_alert.author_name = token['display_name']
     session.add(updated_alert)
+
+    # now handle the cap emissions
+    crud_cap.update_cap_event(session, updated_alert)
     return updated_alert
 
 @router.get("/{alert_id}/caps", response_model=List[cap_models.Cap_Event_And_Areas])

--- a/backend/src/v1/routes/alert_routes.py
+++ b/backend/src/v1/routes/alert_routes.py
@@ -117,8 +117,6 @@ def update_alert(
     #    - record the previous alert status in history
     #    - update the alert record with incomming changes
 
-    # TODO: get the author name from the oidc access token and update before
-    #       sending to the database.
 
     updated_alert = crud_alerts.update_alert(
         session=session, alert_id=alert_id, updated_alert=alert
@@ -128,7 +126,6 @@ def update_alert(
     LOGGER.debug(f"token: {token}")
     updated_alert.author_name = token['display_name']
     session.add(updated_alert)
-    session.commit()
     return updated_alert
 
 @router.get("/{alert_id}/caps", response_model=List[cap_models.Cap_Event_And_Areas])

--- a/backend/src/v1/routes/alert_routes.py
+++ b/backend/src/v1/routes/alert_routes.py
@@ -107,15 +107,18 @@ def update_alert(
     # get existing related (basin and alert_level ) data
     # compare incomming and existing data
     # separate changes into:
-    #   - net new area / alert level added
-    #   - existing area / alert level removed
-    #   - existing area / alert level updated
+    #   - net new area / alert level added - create-ALERT
+    #   - existing area / alert level removed - deleted-CANCEL
+    #   - existing area / alert level updated - update-UPDATE
     #
     # record changes in the alert history table
 
     # has the alert record changed / yes
     #    - record the previous alert status in history
     #    - update the alert record with incomming changes
+
+    # write history
+    
 
 
     updated_alert = crud_alerts.update_alert(

--- a/backend/test/api_tests/test_api_alerts.py
+++ b/backend/test/api_tests/test_api_alerts.py
@@ -129,11 +129,7 @@ def test_alert_patch(test_client_fixture, alert_dict, db_with_alert, mock_access
     prefix = Configuration.API_V1_STR
     db_with_alert.flush()
 
-    # get the alert id
-    # cur_alert = select(alert_model.Alerts).where(alert_model.Alerts.alert_description == alert_dict["alert_description"])
-    # alert_id = cur_alert.alert_id
-    # LOGGER.debug(f"alert_id: {alert_id}")
-
+    # query for all alerts, and grab the first alert
     response = client.get(f"{prefix}/alerts/")
     resp_json = response.json()
     LOGGER.debug(f"resp_json: {resp_json}")
@@ -147,7 +143,7 @@ def test_alert_patch(test_client_fixture, alert_dict, db_with_alert, mock_access
     # update the dict author to the authorname from the simulated access token
     alert_dict["author_name"] = mock_access_token["display_name"]
 
-    # add a basin / alert level
+    # add a basin / alert level and send to api
     alert_dict["alert_links"].append(
         {
             "basin": {"basin_name": "Liard"},

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -129,8 +129,14 @@ def db_sqllite_engine(alert_level_data) -> Generator[Engine, None, None]:
             cap_status = Cap_Event_Status(cap_event_status=cap['cap_event_status'])
             session.add(cap_status)
 
+        # caps got entered incorrectly, there is a migration to address that.  This
+        # method fixes that for the sqllite tests.
+        old_value = 'CREATE'
+        new_value = 'ALERT'
+        query = sqlmodel.select(Cap_Event_Status).where(Cap_Event_Status.cap_event_status==old_value)
+        record = session.exec(query).one()
+        record.cap_event_status = new_value
         session.commit()
-
 
     yield engine
 

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -129,8 +129,12 @@ def db_sqllite_engine(alert_level_data, basin_data) -> Generator[Engine, None, N
         old_value = 'CREATE'
         new_value = 'ALERT'
         query = sqlmodel.select(Cap_Event_Status).where(Cap_Event_Status.cap_event_status==old_value)
-        record = session.exec(query).one()
-        record.cap_event_status = new_value
+        db_record = session.exec(query)
+        record = db_record.all()
+        if len(record):
+            LOGGER.debug(f"number of records: {len(record)}")
+            record = record[0]
+            record.cap_event_status = new_value
         session.commit()
 
     yield engine

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -25,6 +25,8 @@ LOGGER = logging.getLogger(__name__)
 # add fixture modules here
 pytest_plugins = [
     "fixtures.alert_fixtures",
+    "fixtures.data_fixtures",
+    "fixtures.cap_fixtures"
 ]
 
 # used for postgres testing
@@ -69,9 +71,8 @@ def db_pg_session(db_pg_connection: sqlmodel.Session):
     yield db_pg_connection
     db_pg_connection.rollback()
 
-
 @pytest.fixture(scope="session")
-def db_sqllite_engine(alert_level_data) -> Generator[Engine, None, None]:
+def db_sqllite_engine(alert_level_data, basin_data) -> Generator[Engine, None, None]:
     # should re-create the database every time the tests are run, the following
     # line ensure database that maybe hanging around as a result of a failed
     # test is deleted
@@ -102,14 +103,8 @@ def db_sqllite_engine(alert_level_data) -> Generator[Engine, None, None]:
         # loading basin data
         LOGGER.info("loading basin data into test database")
         session = sqlmodel.Session(engine)
-        basin_file = os.path.join(
-            os.path.dirname(__file__), "..", "alembic", "data", "basins.json"
-        )
-        LOGGER.debug(f"src file for basin data: {basin_file}")
-        with open(basin_file, "r") as json_file:
-            basins_data = json.load(json_file)
 
-        for basin in basins_data:
+        for basin in basin_data:
             basin = Basins(basin_name=basin["basin_name"])  # noqa: F405
             session.add(basin)
         # loading alert level data
@@ -146,26 +141,6 @@ def db_sqllite_engine(alert_level_data) -> Generator[Engine, None, None]:
         LOGGER.debug("remove the database: ./test_db.db'")
         # os.remove("./test_db.db")
 
-@pytest.fixture(scope="session")
-def alert_level_data() -> Generator[Alert_Levels_Read, None, None]:  # noqa: F405
-    """
-    reads the alert levels json file and loads to a List[Dict] structure.
-
-    :yield: List
-    :rtype: Generator[Alert_Levels_Read, None, None]
-    """
-
-    alert_level_data_file = os.path.join(
-        os.path.dirname(__file__),
-        "..",
-        "alembic",
-        "data",
-        "alert_levels.json",
-    )
-
-    with open(alert_level_data_file, "r") as json_file:
-        alert_level_data = json.load(json_file)
-    yield alert_level_data
 
 @pytest.fixture(scope="session")
 def db_engine(db_sqllite_engine, db_pg_engine):

--- a/backend/test/db_tests/test_cap_delta.py
+++ b/backend/test/db_tests/test_cap_delta.py
@@ -1,0 +1,253 @@
+import logging
+from typing import Dict, List, TypedDict
+
+import pytest
+from sqlmodel import Session, select
+from src.v1.crud import crud_cap
+from src.v1.models import alerts as alerts_models
+from src.v1.models import basins as basins_models
+from src.v1.models import cap as caps_models
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    "cap_comp_1_dict,cap_comp_2_dict,expected_result",
+    [
+        [{"Level1": ["basin1"]}, {"Level1": ["basin1", "basin2"]}, False],
+        [{"Level1": ["basin2", "basin3", "basin4"]}, {"Level1": ["basin3", "basin2", "basin4"]}, True],
+        [{"Level1": ["basin3", "basin4"]}, {"Level1": ["basin3", "basin2", "basin4"]}, False],
+        [{"Level1": ["basin2", "basin3", "basin4"]}, {"Level2": ["basin3", "basin2", "basin4"]}, False],
+        [{"Level1": ["basin4"]}, {"Level1": ["basin4"]}, True],
+        [{"Level1": []}, {"Level1": ["basin4"]}, False]
+    ]
+)
+def test_is_cap_comp_equal(cap_comp_1_dict, cap_comp_2_dict, expected_result):
+    """
+    tests two cap comparison objects to see if they are equal
+
+    :param cap_comp_1: _description_
+    :type cap_comp_1: _type_
+    :param cap_comp_2: _description_
+    :type cap_comp_2: _type_
+    :return: _description_
+    :rtype: _type_
+    """
+    cap_comp_1 = cap_comp_from_dict(cap_comp_1_dict)
+    cap_comp_2 = cap_comp_from_dict(cap_comp_2_dict)
+    delta_obj = crud_cap.CapDelta(
+        existing_cap_struct=cap_comp_1,
+        new_cap_struct=cap_comp_2)
+    actual_result = delta_obj.is_cap_comp_equal(cap_comp_1, cap_comp_2)
+    assert actual_result == expected_result
+
+
+@pytest.mark.parametrize(
+    "existing_cap_dict,new_caps_dict,cancel_list",
+    [
+        [{"Level1": ["basin1"]}, {"Level1": ["basin1", "basin2"]}, []],
+        [{"Level1": ["basin1"]}, {"Level1": ["basin1"], "Level2": ["basin2"]}, []],
+        [{"Level1": ["basin1"]}, {"Level2": ["basin2"]}, [{"Level1": ["basin1"]}]],
+        [{"Level2": ["basin2"], "Level3": ["basin3"]}, {"Level1": ["basin1"]}, [{"Level2": ["basin2"]}, {"Level3": ["basin3"]}]],
+        [{"Level2": ["basin2", "basin4", "basin3"], "Level3": ["basin7", "basin9"]}, {"Level1": ["basin1"]}, [{"Level2": ["basin2", "basin4", "basin3"]}, {"Level3": ["basin7", "basin9"]}]],
+        [{"Level2": ["basin2", "basin4", "basin3"], "Level3": ["basin7", "basin9"]}, {}, [{"Level2": ["basin2", "basin4", "basin3"]}, {"Level3": ["basin7", "basin9"]}]],
+        [{"Level2": ["basin2", "basin4"]}, {"Level2": ["basin2", "basin4", "basin3"]}, {}],
+        [{"Level1": ["basin2", "basin4"]}, {"Level2": ["basin2", "basin4", "basin3"]}, [{"Level1": ["basin2", "basin4"]}]]
+    ],
+)
+def test_cap_delta_cancels(existing_cap_dict, new_caps_dict, cancel_list):
+    """
+    Tests the cancel method of the cap delta object.  This method is used to
+    determine if a cap event should be cancelled.  This is determined by
+    comparing the existing cap alert levels to the new cap alert levels.  If
+    the new cap alert levels are empty then the cap event should be cancelled.
+
+    :return: None
+    :rtype: None
+    """
+    existing_cap_comp = cap_comp_from_dict(existing_cap_dict)
+    new_cap_comp = cap_comp_from_dict(new_caps_dict)
+
+    expected_cap_comp = []
+    for cancel_dict in cancel_list:
+        expected_cap_comp.extend(cap_comp_from_dict(cancel_dict))
+
+
+    delta_obj = crud_cap.CapDelta(
+        existing_cap_struct=existing_cap_comp,
+        new_cap_struct=new_cap_comp)
+    
+    actual_cancels = delta_obj.getCancels()
+    LOGGER.debug(f"actual_cancels: {actual_cancels}")
+    LOGGER.debug(f"expected cancels: {expected_cap_comp}")
+    equal = delta_obj.is_cap_comp_equal(expected_cap_comp, actual_cancels)
+    LOGGER.debug(f"are objects equal: {equal}")
+    assert equal
+
+
+@pytest.mark.parametrize(
+    "existing_cap_dict,new_caps_dict,update_list",
+    [
+        [{"Level1": ["basin1"]}, {"Level1": ["basin1", "basin2"]}, [{"Level1": ["basin1", "basin2"]}]],
+        [{"Level1": ["basin1"]}, {"Level1": ["basin1"]}, []],
+        [{"Level1": ["basin1", 'basin2']}, {"Level1": ["basin1"]}, [{"Level1": ["basin1"]}]],
+        [{}, {"Level1": ["basin1"]}, []],
+        [{"Level1": ["basin1", 'basin2', 'basin55'], "Level2": {"basin3", "basin4"}}, {"Level1": ["basin1", 'basin2'], "Level2": {"basin3", "basin4", "basin5"}}, [{"Level1": ["basin1", 'basin2']}, {"Level2": {"basin3", "basin4", "basin5"}} ]],
+    ],
+)
+def test_cap_delta_updates(existing_cap_dict, new_caps_dict, update_list):
+    """
+    Updates are defined by a change to the area affected in an existing alert level.
+
+    Example the area expands or contracts for an existing cap alert level.
+
+    Scenarios to test:
+    - basin added
+    - basin removed
+    - new alert level and basin - this is a create, and should not emit an update
+    - alert level removed and all basins - this is a delete, and should not emit an update
+
+    :param existing_cap_dict: input cap comparison dictionary representing an existing
+        state of cap alert levels in the database.
+
+    :type existing_cap_dict: dict
+    :param new_caps_dict: same as existing_cap_dict, except this represents the new state
+        as a result of edits to the related alert
+    :type new_caps_dict: dict
+    :param create_list: a list of dictionaries describing the updates that should be 
+        issued.
+    :type create_list: list
+    """
+    existing_cap_comp = cap_comp_from_dict(existing_cap_dict)
+    new_cap_comp = cap_comp_from_dict(new_caps_dict)
+
+    delta_obj = crud_cap.CapDelta(
+        existing_cap_struct=existing_cap_comp,
+        new_cap_struct=new_cap_comp)
+    actual_updates = delta_obj.getUpdates()
+    LOGGER.debug(f"actual_updates: {actual_updates}")
+
+    actual_updates_list = cap_comp_to_dict(actual_updates)
+    LOGGER.debug(f"actual_updates_list: {actual_updates_list}")
+    LOGGER.debug(f"expected updates: {update_list}")
+
+    expected_cap_comp = []
+    for update_dict in update_list:
+        expected_cap_comp.extend(cap_comp_from_dict(update_dict))
+    LOGGER.debug(f"expected_cap_comp: {expected_cap_comp}")
+
+    # LOGGER.debug("creates: " + str(creates))
+    # expected_updates_list = cap_comp_to_dict(update_list)
+    # LOGGER.debug(f"updates: {expected_updates_list}")
+
+    equal = delta_obj.is_cap_comp_equal(expected_cap_comp, actual_updates)
+    LOGGER.debug(f"are objects equal: {equal}")
+    assert equal
+
+
+@pytest.mark.parametrize(
+    "existing_cap_dict,new_caps_dict,create_list",
+    [
+        [{"Level1": ["basin1"]}, {"Level1": ["basin1", "basin2"]}, []],
+        [{"Level1": ["basin1"]}, {"Level1": ["basin1"], "Level2": ["basin2"]}, [{"Level2": ["basin2"]}]],
+        [{"Level1": ["basin1"]}, {"Level2": ["basin2"]}, [{"Level2": ["basin2"]}]],
+        [{"Level1": ["basin1"]}, {"Level2": ["basin2"], "Level3": ["basin3"]}, [{"Level2": ["basin2"]}, {"Level3": ["basin3"]}]],
+        [{"Level1": ["basin1"]}, {"Level2": ["basin2", "basin4", "basin3"], "Level3": ["basin7", "basin9"]}, [{"Level2": ["basin2", "basin4", "basin3"]}, {"Level3": ["basin7", "basin9"]}]],
+        [{}, {"Level2": ["basin2", "basin4", "basin3"], "Level3": ["basin7", "basin9"]}, [{"Level2": ["basin2", "basin4", "basin3"]}, {"Level3": ["basin7", "basin9"]}]],
+        [{"Level2": ["basin2", "basin4", "basin3"]}, {"Level2": ["basin2", "basin4"]}, {}]
+    ],
+)
+def test_cap_delta_adds(existing_cap_dict, new_caps_dict, create_list):
+    """
+    existing_cap_dict
+        key: alert level, example 'Level1'
+        value: list of basins, example ['basin1', 'basin2']
+
+    new_caps_dict
+        same struct as the existing_cap_dict
+
+    create_list
+        list of dictionaries that describes the differences between the existing_cap_dict
+        and the new_caps_dict.
+
+    * note the levels are not enforced, that will take place higher up in the code
+      at the database (crud) level.  the cap_delta is only responsible for identifying
+      how caps have changed and what actions need to take place as a result of those
+      changes.
+
+    [level, [basin list]]
+
+    fixture provides detail about the 
+
+    # things to test
+    - basin added
+    - basin removed
+    - new alert level
+    - new alert level and basin
+    - alert level removed and all basins
+    """
+    LOGGER.debug(f"existing_cap_dict: {existing_cap_dict}")
+
+    existing_cap_comp = cap_comp_from_dict(existing_cap_dict)
+    new_cap_comp = cap_comp_from_dict(new_caps_dict)
+
+    expected_cap_comp = []
+    for create_dict in create_list:
+        expected_cap_comp.extend(cap_comp_from_dict(create_dict))
+    #expected_cap_comp = cap_comp_from_dict(create_list)
+    
+    delta_obj = crud_cap.CapDelta(
+        existing_cap_struct=existing_cap_comp,
+        new_cap_struct=new_cap_comp)
+    actual_creates = delta_obj.getCreates()
+    LOGGER.debug(f"expected_creates: {actual_creates}")
+    # LOGGER.debug("creates: " + str(creates))
+    # actual_creates_list = cap_comp_to_dict(creates)
+    # LOGGER.debug(f"creates: {creates}")
+    # LOGGER.debug(f"actual_creates_list: {actual_creates_list}")
+    equal = delta_obj.is_cap_comp_equal(expected_cap_comp, actual_creates)
+    LOGGER.debug(f"are objects equal: {equal}")
+    assert equal
+
+
+def cap_comp_from_dict(cap_comp_dict) -> List[caps_models.Cap_Comparison]:
+    """
+    create a cap comparison object from a dictionary
+
+    :param cap_comp_dict: dictionary containing the alert level and basin data
+    :type cap_comp_dict: dict
+    :return: cap comparison object
+    :rtype: cap_models.Cap_Comparison
+    """
+    cap_comps = []
+    for alert_level in cap_comp_dict.keys():
+        alert_lvl_model = alerts_models.Alert_Levels_Base(alert_level=alert_level)
+        basins = []
+        for basin in cap_comp_dict[alert_level]:
+            basin_model = basins_models.BasinBase(basin_name=basin)
+            basins.append(basin_model)
+        cap_comp = caps_models.Cap_Comparison(alert_level=alert_lvl_model, basins=basins)
+        cap_comps.append(cap_comp)
+    return cap_comps
+
+def cap_comp_to_dict(cap_comp: List[caps_models.Cap_Comparison]) -> List[Dict[str, List[str]]]:
+    """
+    create a cap comparison object from a dictionary
+
+    :param cap_comp: dictionary containing the alert level and basin data
+    :type cap_comp: dict
+    :return: cap comparison object
+    :rtype: cap_models.Cap_Comparison
+    """
+    LOGGER.debug(f"input cap comp: {cap_comp}")
+    cap_comps = []
+    for cap in cap_comp:
+        alert_level = cap.alert_level.alert_level
+        LOGGER.debug(f"comp, alert_level: {alert_level}")
+        basins = []
+        for basin in cap.basins:
+            basins.append(basin.basin_name)
+        basins.sort()
+        cap_comps.append({alert_level: basins})
+    #cap_comps.sort()
+    return cap_comps

--- a/backend/test/db_tests/test_db_cap.py
+++ b/backend/test/db_tests/test_db_cap.py
@@ -16,23 +16,22 @@ LOGGER = logging.getLogger(__name__)
 def test_create_cap_event(db_with_alert_and_data, alert_dict: typing.Dict):
     session = db_with_alert_and_data[0]
     alert_data = db_with_alert_and_data[1]
-    session.flush()
+
+    # create cap events from the alert
     caps = crud_cap.create_cap_event(session=session, alert=alert_data)
     session.flush()
     LOGGER.debug(f"cap: {caps}")
-    # each cap event can only contain a single alert level.
-    # separate the dict data into the unique number of alert levels then 
-    # verify that the number of alert levels in the alert corresponds with the 
-    # number of cap events
+
+    # create a list of alert levels associated with the current alert
     alert_levels = [alert_link["alert_level"]["alert_level"] for alert_link in alert_dict["alert_links"] ]
-    alert_levels = set(alert_levels)
+    alert_levels = list(set(alert_levels)) # remove any duplicates
     assert len(alert_levels) == len(caps)
 
-    # getting the alert level id's from the db
+    # dictionary mapping the primary keys to the alert level strings
     alert_lvl_dict = get_alert_level_dict(session)
     LOGGER.debug(f"alert_lvl_dict: {alert_lvl_dict}")
 
-    # getting the basin_id to basin name lookup table
+    # getting the basin_id (fk) to basin name lookup table
     basin_dict = get_basin_dict(session)
     basin_query = select(basin_models.Basins)
     basin_results = session.exec(basin_query).all()
@@ -42,18 +41,23 @@ def test_create_cap_event(db_with_alert_and_data, alert_dict: typing.Dict):
 
     # verify all the alert levels in the cap are in the original alert
     for cap in caps:
-        assert alert_lvl_dict[cap.alert_level.alert_level_id] in alert_levels
+        # verify that the primary key aligns with the table
+        assert cap.alert_level.alert_level in alert_levels
+
         # get the basins in the original alert that have the alert_level set
         # to the current alert level
-        alert_basins = [alert_link['basin']['basin_name'] for alert_link in alert_dict['alert_links'] if alert_link['alert_level']['alert_level'] == alert_lvl_dict[cap.alert_level.alert_level_id]]
+        alert_basins = [alert_link['basin']['basin_name'] for alert_link in alert_dict['alert_links'] if alert_link['alert_level']['alert_level'] == cap.alert_level.alert_level]
         LOGGER.debug(f"basins for the alert level {alert_lvl_dict[cap.alert_level.alert_level_id]}: {alert_basins}")
+
         # now get the basins for the cap event and verify they are in the original
         # alert
         for event_area in cap.event_areas:
             LOGGER.debug(f"event area link: {event_area}")
+            LOGGER.debug(f"event area link basin: {event_area.cap_area_basin.basin_name}")
+
             # get the basins in the original alert that have the alert_level set
             # to the current alert level
-            assert basin_dict[event_area.basin_id] in alert_basins
+            assert event_area.cap_area_basin.basin_name in alert_basins
 
 def test_get_cap_event(db_with_alert_and_caps, alert_dict):
     LOGGER.debug(f"db_with_alert_and_caps: {db_with_alert_and_caps}")
@@ -122,39 +126,38 @@ def test_edit_alert_cap_events(db_with_alert_and_caps):
         crud_cap.update_cap_event(session, alert)
 
 @pytest.mark.parametrize(
-        "input_alert_dict,updated_alert_dict",
+        "input_alert_list,updated_alert_list",
         [
             [
-                {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast', 'Eastern Vancouver Island']},
-                {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast']}
+                [{'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast', 'Eastern Vancouver Island']}],
+                [{'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast']}]
             ],
             [
-                {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast']},
-                {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast', 'Eastern Vancouver Island']}
+                [{'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast']}],
+                [{'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast', 'Eastern Vancouver Island']}]
             ],
             [
-                {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast']},
-                {'alert_level': 'Flood Watch', 'basin_names': ['Central Coast']}
+                [{'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast']}],
+                [{'alert_level': 'Flood Watch', 'basin_names': ['Central Coast']}]
             ],
             [
-                {'alert_level': 'Flood Watch', 'basin_names': ['Central Coast']},
-                {'alert_level': 'Flood Watch', 'basin_names': ['Central Coast']}
+                [{'alert_level': 'Flood Watch', 'basin_names': ['Central Coast']}],
+                [{'alert_level': 'Flood Watch', 'basin_names': ['Central Coast']}]
             ],
             [
-                {'alert_level': 'Flood Watch', 'basin_names': ['Central Coast']},
-                {'alert_level': 'Flood Watch', 'basin_names': []}
+                [{'alert_level': 'Flood Watch', 'basin_names': ['Central Coast']}],
+                [{'alert_level': 'Flood Watch', 'basin_names': []}]
             ],
 
         ]
 )
-def test_record_cap_event_history(db_test_connection, input_alert_dict, updated_alert_dict):
+def test_record_cap_event_history(db_test_connection, input_alert_list, updated_alert_list):
     session = db_test_connection
     LOGGER.debug(f"sesion: {db_test_connection}")
-    LOGGER.debug(f"input_alert_dict: {input_alert_dict}")
 
     # create two fake alerts
-    input_alert = create_fake_alert(input_alert_dict)
-    updated_alert = create_fake_alert(updated_alert_dict)
+    input_alert = create_fake_alert(input_alert_list)
+    updated_alert = create_fake_alert(updated_alert_list)
     LOGGER.debug(f"input_alert: {input_alert}")
 
     # add the 'input_alert' alert to the database transaction, and generate caps for 
@@ -190,11 +193,208 @@ def test_record_cap_event_history(db_test_connection, input_alert_dict, updated_
             basin_names = []
             for basin in cap_hist_record.cap_event_areas_hist:
                 basin_names.append(basin.basins.basin_name)
+                input_alert_dict = [alert for alert in input_alert_list if alert['alert_level'] == cap_hist_record.alert_levels.alert_level][0]
                 assert basin.basins.basin_name in input_alert_dict['basin_names']
             # there should be a record that corresponds with the alert level
             
             assert cap_hist_record.alert_levels.alert_level == input_alert_dict['alert_level']
     session.rollback()
+
+@pytest.mark.parametrize(
+        "existing_alert_list,updated_alert_list",
+        [
+            [
+                [
+                    {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast', 'Eastern Vancouver Island']}
+                ],
+                [
+                    {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast', 'Eastern Vancouver Island']},
+                    {'alert_level': 'Flood Watch', 'basin_names': ['North Coast', 'Stikine']}
+                ]
+            ],
+            [
+                [
+                    {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast', 'Eastern Vancouver Island']},
+                    {'alert_level': 'Flood Watch', 'basin_names': ['North Coast', 'Stikine']}
+                ],
+                [
+                    {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast', 'Eastern Vancouver Island']},
+                    {'alert_level': 'Flood Watch', 'basin_names': ['North Coast', 'Stikine']},
+                    {'alert_level': 'Flood Warning', 'basin_names': ['Skeena', 'Northwest']}
+                ],
+            ]
+        ]
+)
+def test_new_cap_for_alert(db_test_connection, existing_alert_list, updated_alert_list):
+    """
+    _summary_
+
+    :param db_test_connection: a database session / transaction
+    :type db_test_connection: Session.session
+    :param existing_alert_list: a list of dictionaries that describes the alert level 
+        and the basins for a hypothetical alert.  This represents the state of the 
+        alert in the database prior to an update
+    :type existing_alert_list: typing.List[typing.Dict]
+    :param updated_alert_list: a list of dictionaries that describe the new state
+        of the alert levels and basins for an incomming update for an alert
+    :type updated_alert_list: typing.List[typing.Dict]
+    """
+    session = db_test_connection
+    LOGGER.debug(f"input_alert_list: {existing_alert_list}")
+    LOGGER.debug(f"updated_alert_list: {updated_alert_list}")
+    
+    # create the fake alerts, and caps.  These represent the existing state before
+    # an update is performed
+    input_alert = create_fake_alert(existing_alert_list)
+    input_alert_db = crud_alerts.create_alert(session=session, alert=input_alert)
+    caps = crud_cap.create_cap_event(session=session, alert=input_alert_db)
+    LOGGER.debug(f"caps for new alert: {caps}")
+
+    # create the updated alert
+    updated_alert = create_fake_alert(updated_alert_list)
+    updated_alert_db = crud_alerts.create_alert(session=session, alert=updated_alert)
+
+    # generate a cap comp object
+    cap_comp = crud_cap.CapCompare(session, updated_alert_db)
+    cap_delta = cap_comp.get_delta()
+    creates = cap_delta.getCreates()
+
+    LOGGER.debug(f"creates {creates}")
+
+    # create a new cap event for an existing alert
+    crud_cap.new_cap_for_alert(
+        session=session, alert=updated_alert_db, cap_comps=creates)
+
+    # testing to make sure the new cap event for the existing alert is correct
+
+    # - retrieve the existing caps for the alert
+    cap_query = select(cap_models.Cap_Event).where(cap_models.Cap_Event.alert_id == updated_alert_db.alert_id)
+    existing_caps = session.exec(cap_query).all()
+
+    # - verify that the cap events for the alert align with what is expected
+    #   - create a dict for lookup of alert levels
+    alert_lvl_dict = {}
+    for alert_lvl in updated_alert_list:
+        alert_lvl_dict[alert_lvl['alert_level']] = alert_lvl
+
+    for cap in existing_caps:
+        LOGGER.debug(f"cap: {cap}")
+        # - verify that the alert id is correct
+        assert cap.alert_id == updated_alert_db.alert_id
+
+        # - verify that the alert level is correct
+        assert cap.alert_level.alert_level in alert_lvl_dict.keys()
+
+        # - verify that the basins are correct
+        for event_area in cap.event_areas:
+            assert event_area.cap_area_basin.basin_name in alert_lvl_dict[cap.alert_level.alert_level]['basin_names']
+
+    assert len(existing_caps) == len(updated_alert_list)
+    # TODO: verify that the cap status is set to ALERT
+
+
+
+@pytest.mark.parametrize(
+        "existing_alert_list,updated_alert_list",
+        [
+            [
+                [
+                    {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast', 'Eastern Vancouver Island']}
+                ],
+                [
+                    {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast', 'Eastern Vancouver Island', 'Skeena']},
+                ]
+            ],
+            [
+                [
+                    {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast', 'Eastern Vancouver Island', 'Skeena']},
+                    {'alert_level': 'Flood Watch', 'basin_names': ['North Coast', 'Stikine']}
+                ],
+                [
+                    {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast', 'Eastern Vancouver Island']},
+                    {'alert_level': 'Flood Watch', 'basin_names': ['North Coast', 'Stikine', "Skeena"]}
+                ],
+            ],
+            [
+                [
+                    {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast']},
+                    {'alert_level': 'Flood Watch', 'basin_names': ['North Coast', 'Stikine']}
+                ],
+                [
+                    {'alert_level': 'High Streamflow Advisory', 'basin_names': ['Central Coast', 'Eastern Vancouver Island', 'Skeena']},
+                    {'alert_level': 'Flood Watch', 'basin_names': ['North Coast', 'Stikine', "Skeena"]}
+                ],
+            ]
+        ]
+)
+def test_update_cap_for_alert(db_test_connection, existing_alert_list, updated_alert_list):
+    session = db_test_connection
+    
+    # create the fake alerts, and caps.  These represent the existing state before
+    # an update is performed
+    input_alert = create_fake_alert(existing_alert_list)
+    input_alert_db = crud_alerts.create_alert(session=session, alert=input_alert)
+    caps = crud_cap.create_cap_event(session=session, alert=input_alert_db)
+    # session.flush()
+    # HERE.... something is wrong with the caps... relationships are not loading
+    # debugging to verify that relationships where added
+
+    LOGGER.debug(f"caps created for alert: {caps}, {type(caps)}")
+
+    # LOGGER.debug(f"input_alert_db: {input_alert_db}, {type(input_alert_db)}")
+    # LOGGER.debug(f"alert id: {input_alert_db.alert_id}")
+    # LOGGER.debug(f"input_alert_db.alert_level_id: {input_alert_db.alert_level_id}")
+    # cap_query = select(cap_models.Cap_Event).where(
+    #     cap_models.Cap_Event.alert_id == input_alert_db.alert_id).where(
+    #     cap_models.Cap_Event.alert_level_id == input_alert_db.alert_level_id)
+    # cap_data = session.exec(cap_query).all()
+    # LOGGER.debug(f"cap_query: {cap_query}")
+    # LOGGER.debug(f"cap_query: {cap_data}")
+
+
+    # update the alert previously created
+    updated_alert = update_fake_alert(existing_alert=input_alert_db, alert_list=updated_alert_list)
+    updated_alert_db = crud_alerts.update_alert(
+        session=session, alert_id=input_alert_db.alert_id, updated_alert=updated_alert)
+    LOGGER.debug(f"updated_alert: {updated_alert_db}")
+
+    # generate a cap comp object
+    cap_comp = crud_cap.CapCompare(session, updated_alert_db)
+    cap_delta = cap_comp.get_delta()
+    updates = cap_delta.getUpdates()
+
+    LOGGER.debug(f"updates {updates}")
+
+    # create a new cap event for an existing alert
+    crud_cap.update_cap_for_alert(
+        session=session, alert=updated_alert_db, cap_comps=updates)
+    
+    # now to the assertions
+    # - retrieve the existing caps for the alert
+    cap_query = select(cap_models.Cap_Event).where(cap_models.Cap_Event.alert_id == updated_alert_db.alert_id)
+    existing_caps = session.exec(cap_query).all()
+
+    # - verify that the cap events for the alert align with what is expected
+    #   - create a dict for lookup of alert levels
+    alert_lvl_dict = {}
+    for alert_lvl in updated_alert_list:
+        alert_lvl_dict[alert_lvl['alert_level']] = alert_lvl
+
+    for cap in existing_caps:
+        LOGGER.debug(f"cap: {cap}")
+        # - verify that the alert id is correct
+        assert cap.alert_id == updated_alert_db.alert_id
+
+        # - verify that the alert level is correct
+        assert cap.alert_level.alert_level in alert_lvl_dict.keys()
+
+        # - verify that the basins are correct
+        for event_area in cap.event_areas:
+            assert event_area.cap_area_basin.basin_name in alert_lvl_dict[cap.alert_level.alert_level]['basin_names']
+
+    assert len(existing_caps) == len(updated_alert_list)
+    # TODO: verify that the cap status is set to UPDATE
+
 
 
 def get_alert_level_dict(session: Session):
@@ -231,7 +431,7 @@ def get_basin_dict(session: Session):
     return basin_dict
 
 
-def create_fake_alert(alert_dict: typing.Dict) -> alerts_models.Alert_Basins_Write:
+def create_fake_alert(alert_list: typing.List[typing.Dict]) -> alerts_models.Alert_Basins_Write:
     """
     creates a fake alert object from a dictionary.  The dictionary is expected
     to contain the following keys:
@@ -241,15 +441,16 @@ def create_fake_alert(alert_dict: typing.Dict) -> alerts_models.Alert_Basins_Wri
     :param alert_dict: a dictionary containing the alert level and basin names
     :type alert_dict: typing.Dict
     """
-    LOGGER.debug(f"alert_dict: {alert_dict}")
+    LOGGER.debug(f"alert_dict: {alert_list}")
     alert_area_list = []
-    for basin_name in alert_dict["basin_names"]:
-        LOGGER.debug(f"basin_name: {basin_name}")
-        alert_area = alerts_models.Alert_Areas_Write(
-            alert_level=alerts_models.Alert_Levels_Base(alert_level=alert_dict["alert_level"]),
-            basin=basin_models.BasinBase(basin_name=basin_name)
-        )
-        alert_area_list.append(alert_area)
+    for alert_dict in alert_list:
+        for basin_name in alert_dict["basin_names"]:
+            LOGGER.debug(f"basin_name: {basin_name}")
+            alert_area = alerts_models.Alert_Areas_Write(
+                alert_level=alerts_models.Alert_Levels_Base(alert_level=alert_dict["alert_level"]),
+                basin=basin_models.BasinBase(basin_name=basin_name)
+            )
+            alert_area_list.append(alert_area)
 
     fakeInst = faker.Faker("en_US")
 
@@ -270,3 +471,43 @@ def create_fake_alert(alert_dict: typing.Dict) -> alerts_models.Alert_Basins_Wri
     )
     LOGGER.debug(f"fake alert: {alert}")
     return alert
+
+
+#     update_fake_alert(session=session, input_alert_db, updated_alert_list)
+def update_fake_alert(
+        existing_alert: alerts_models.Alerts,
+        alert_list: typing.List[typing.Dict]) -> alerts_models.Alert_Basins_Write:
+    """
+    used to simulate the condition where an alert has been updated and now the 
+    caps associated with that alert need to be updated.
+    """
+    # create the alert area / alert level list to be added to the alert object
+    # further down in the function 
+    alert_area_list = []
+    for alert_dict in alert_list:
+        for basin_name in alert_dict["basin_names"]:
+            LOGGER.debug(f"basin_name: {basin_name}")
+            alert_area = alerts_models.Alert_Areas_Write(
+                alert_level=alerts_models.Alert_Levels_Base(alert_level=alert_dict["alert_level"]),
+                basin=basin_models.BasinBase(basin_name=basin_name)
+            )
+            alert_area_list.append(alert_area)
+
+    fakeInst = faker.Faker("en_US")
+    auth = fakeInst.name()
+
+    # mostly copy the attributes from the incomming alert, with the exception of 
+    # author, update time, and alert area / alert levels
+    updated_alert = alerts_models.Alert_Basins_Write(
+        alert_description=existing_alert.alert_description,
+        alert_hydro_conditions=existing_alert.alert_hydro_conditions,
+        alert_meteorological_conditions=existing_alert.alert_meteorological_conditions,
+        author_name=auth,
+        alert_status=existing_alert.alert_status,
+        alert_created=existing_alert.alert_created,
+        alert_updated=datetime.datetime.now(datetime.timezone.utc),
+        alert_links=alert_area_list
+    )
+    return updated_alert
+
+

--- a/backend/test/db_tests/test_db_cap.py
+++ b/backend/test/db_tests/test_db_cap.py
@@ -293,7 +293,6 @@ def test_new_cap_for_alert(db_test_connection, existing_alert_list, updated_aler
     # TODO: verify that the cap status is set to ALERT
 
 
-
 @pytest.mark.parametrize(
         "existing_alert_list,updated_alert_list",
         [
@@ -394,6 +393,10 @@ def test_update_cap_for_alert(db_test_connection, existing_alert_list, updated_a
 
     assert len(existing_caps) == len(updated_alert_list)
     # TODO: verify that the cap status is set to UPDATE
+    for cap in existing_caps:
+        assert cap.cap_event_status.cap_event_status == "UPDATE"
+
+    session.rollback()
 
 
 

--- a/backend/test/db_tests/test_db_cap.py
+++ b/backend/test/db_tests/test_db_cap.py
@@ -121,15 +121,6 @@ def test_edit_alert_cap_events(db_with_alert_and_caps):
         # send to cap update
         crud_cap.update_cap_event(session, alert)
 
-
-# moving to parameterize this test.  Inputs are defined as dictionaries and 
-# are converted to pydantic models.
-#  alert:
-#    - alert_relation
-#       - alert_level = ''
-#       - basins_names = []
-#    - alert hydro conditions (faker)
-#    - alert meteorlogical conditions (faker)
 @pytest.mark.parametrize(
         "input_alert_dict,updated_alert_dict",
         [

--- a/backend/test/fixtures/alert_fixtures.py
+++ b/backend/test/fixtures/alert_fixtures.py
@@ -77,14 +77,14 @@ def db_with_alert(
 
 
 @pytest.fixture(scope="function")
-def db_with_alert_and_data(db_test_connection, monkeypatch, alert_basin_write):
+def db_with_alert_and_data(db_test_connection, monkeypatch, alert_basin_write: alerts_models.Alert_Basins_Write):
     monkeypatch.setattr(src.db.session, "engine", db_test_connection.bind)
 
     alert = crud_alerts.create_alert(
         session=db_test_connection, alert=alert_basin_write
     )
     db_test_connection.flush()
-    yield [db_test_connection, alert]
+    yield (db_test_connection, alert)
     db_test_connection.rollback()
 
 

--- a/backend/test/fixtures/cap_fixtures.py
+++ b/backend/test/fixtures/cap_fixtures.py
@@ -1,0 +1,69 @@
+import logging
+
+import pytest
+import src.v1.models.alerts as alerts_models
+import src.v1.models.basins as basins_models
+import src.v1.models.cap as cap_models
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def single_level_cap_comp(alert_level_data, basin_data):
+    """
+    returns a cap comparison object with a single alert level and a single basin
+
+    :param alert_level_data: _description_
+    :type alert_level_data: _type_
+    :param basin_data: _description_
+    :type basin_data: _type_
+    :yield: _description_
+    :rtype: _type_
+    """
+    LOGGER.debug(f"basin_data: {basin_data}")
+
+    alert_level = alerts_models.Alert_Levels_Base(alert_level=alert_level_data[0]["alert_level"])
+    basin = basins_models.BasinBase(basin_name=basin_data[0]["basin_name"])
+    cap_comp = cap_models.Cap_Comparison(alert_level=alert_level, basins=[basin])
+    yield cap_comp
+
+
+@pytest.fixture(scope="function")
+def all_alert_level_caps_comp(alert_level_data, basin_data):
+    """
+    returns a list of cap comparison objects for each possible defined alert level
+    each cap comparion object will have 5 different basins associated with it.
+
+    :param alert_level_data: _description_
+    :type alert_level_data: _type_
+    :param basin_data: _description_
+    :type basin_data: _type_
+    :yield: _description_
+    :rtype: _type_
+    """
+    LOGGER.debug(f"basin_data: {basin_data}")
+
+    chunk_size = 5
+    basin_chunks_list = []
+    basin_list = []
+    # organized basin data into chunks defined by chunk_size, then apply different
+    # chunks later on to different alert levels.
+    basin_cnt = 0
+    for basin in basin_data:
+        basin_model = basins_models.BasinBase(basin_name=basin['basin_name'])
+        basin_list.append(basin_model)
+        if len(basin_list) >= chunk_size:
+            basin_chunks_list.append(basin_list)
+            basin_list = []
+
+    all_caps = []
+    for alert_level in alert_level_data:
+        alert_level_str = alert_level["alert_level"]
+        alert_level = alerts_models.Alert_Levels_Base(alert_level=alert_level_str)
+        basins = basin_chunks_list.pop()
+        cap_comp = cap_models.Cap_Comparison(alert_level=alert_level, basins=basins)
+        all_caps.append(cap_comp)
+    yield all_caps
+
+
+

--- a/backend/test/fixtures/data_fixtures.py
+++ b/backend/test/fixtures/data_fixtures.py
@@ -1,0 +1,43 @@
+import json
+import logging
+import os
+from typing import Generator
+
+import pytest
+from src.v1.models import alerts as alerts_model  # noqa: F403
+
+LOGGER = logging.getLogger(__name__)
+
+@pytest.fixture(scope="session")
+def alert_level_data() -> Generator[alerts_model.Alert_Levels_Read, None, None]:  # noqa: F405
+    """
+    reads the alert levels json file and loads to a List[Dict] structure.
+
+    :yield: List
+    :rtype: Generator[Alert_Levels_Read, None, None]
+    """
+
+    alert_level_data_file = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "alembic",
+        "data",
+        "alert_levels.json",
+    )
+
+    with open(alert_level_data_file, "r") as json_file:
+        alert_level_data = json.load(json_file)
+    yield alert_level_data
+
+@pytest.fixture(scope="session")
+def basin_data():
+    basin_file = os.path.join(
+        os.path.dirname(__file__), "..", "..", "alembic", "data", "basins.json"
+    )
+    LOGGER.debug(f"src file for basin data: {basin_file}")
+    with open(basin_file, "r") as json_file:
+        basins_data = json.load(json_file)
+    yield basins_data
+
+    


### PR DESCRIPTION
When a new area is added to an alert, it will also update the associated cap event.

In working on this issue ended up delivering the following as well:
* ability to identify the ALERT/UPDATE/CANCEL, CAP event statuses based on how a related cap event has changed
* tests to verify the database cap crud functions

Most of what has been added has been added to help make it possible to deliver this feature, while at the same time creating helper functions to facilitate delivering other features.

Closing this ticket now, as the database functionality is now available and working correctly.  

Will create new tickets to describe any deficiencies with this ticket, for example the frontend is not updating correctly when new areas are  added to an alert.


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-rfc-alertauthoring-107-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-rfc-alertauthoring-107-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-rfc-alertauthoring/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-rfc-alertauthoring/actions/workflows/merge.yml)