### PR TITLE
feat: 113 alert cancel caps

### DIFF
--- a/backend/src/types.py
+++ b/backend/src/types.py
@@ -1,3 +1,10 @@
+import typing
+
 from typing_extensions import TypedDict
 
 AlertAreaLevel = TypedDict("AlertAreaLevel", {"basin": str, "alert_level": int})
+
+
+AlertDataDict = typing.TypedDict(
+    "AlertDataDict", {"alert_level": str, "basin_names": typing.List[str]}
+)

--- a/backend/src/v1/routes/alert_routes.py
+++ b/backend/src/v1/routes/alert_routes.py
@@ -103,30 +103,15 @@ def update_alert(
     current_status_alert = crud_alerts.get_alert(session, alert_id=alert_id)
     LOGGER.debug(f"current description: {current_status_alert}")
     LOGGER.debug(f"incomming description: {alert.alert_description}")
-    # get incomming related (basin and alert_level) data
-    # get existing related (basin and alert_level ) data
-    # compare incomming and existing data
-    # separate changes into:
-    #   - net new area / alert level added - create-ALERT
-    #   - existing area / alert level removed - deleted-CANCEL
-    #   - existing area / alert level updated - update-UPDATE
-    #
     # record changes in the alert history table
     crud_alerts.create_history_record(session, current_status_alert)
 
-    # has the alert record changed / yes
-    #    - record the previous alert status in history
-    #    - update the alert record with incomming changes
-
-    # write history
-
-    # need to write the alert history here
-    #  TODO: --- ALERT HISTORY OPERATION goes here
-
+    # update the alert
     updated_alert = crud_alerts.update_alert(
         session=session, alert_id=alert_id, updated_alert=alert
     )
     LOGGER.debug(f"updated_alert: {updated_alert}")
+    
     # now update the author from the access token
     LOGGER.debug(f"token: {token}")
     updated_alert.author_name = token["display_name"]

--- a/backend/test/api_tests/test_api_alerts.py
+++ b/backend/test/api_tests/test_api_alerts.py
@@ -368,3 +368,22 @@ def test_create_alert_history(
     cleanup.cleanup(alert_id=existing_alert["alert_id"])
 
     session.commit()
+
+
+def test_alert_cancel(
+    test_client_fixture: fastapi.testclient,
+    db_test_connection: Session,
+    existing_alert_list: typing.List[AlertDataDict],
+):
+    """
+    Setup, will create a alert, and then update that alert through the api, setting
+    its status to 'Cancelled'
+
+    The following will then be verified:
+        * caps exist for the alert prior to the update
+        * after the alert caps have all been cancelled
+        * the alert status is 'Cancelled'
+        * the alert history record has the correct status (previous status)
+    """
+    # TODO: implement this test
+    pass

--- a/backend/test/api_tests/test_api_alerts.py
+++ b/backend/test/api_tests/test_api_alerts.py
@@ -11,6 +11,7 @@ import pytest
 import src.v1.crud.crud_alerts as crud_alerts
 from sqlmodel import Session
 from src.core.config import Configuration
+from src.types import AlertDataDict
 from src.v1.models import alerts as alert_model
 
 LOGGER = logging.getLogger(__name__)
@@ -258,7 +259,7 @@ def test_get_alert_levels(
 def test_create_alert_history(
     test_client_fixture: fastapi.testclient,
     db_test_connection: Session,
-    existing_alert_list: typing.List[alert_helpers.AlertDataDict],
+    existing_alert_list: typing.List[AlertDataDict],
 ):
     """
     Create a alert through the API, then verify that it exists in the database.

--- a/backend/test/api_tests/test_api_caps.py
+++ b/backend/test/api_tests/test_api_caps.py
@@ -84,12 +84,3 @@ def test_get_caps(db_with_alert: Session, test_client_with_alert_and_cap, alert_
                 )
 
 
-def test_alert_cancel():
-    """
-    This test will run through various scenarios where the status of an alert
-    is changed from 'active' to 'cancel'
-
-    The test will verify that when this takes place any caps that have been
-    created for the alert are set to cancelled as well
-    """
-    pass

--- a/backend/test/api_tests/test_api_caps.py
+++ b/backend/test/api_tests/test_api_caps.py
@@ -7,6 +7,7 @@ from src.core.config import Configuration
 
 LOGGER = logging.getLogger(__name__)
 
+
 def test_get_caps(db_with_alert: Session, test_client_with_alert_and_cap, alert_dict):
     client = test_client_with_alert_and_cap[0]
     session = test_client_with_alert_and_cap[1]
@@ -27,11 +28,13 @@ def test_get_caps(db_with_alert: Session, test_client_with_alert_and_cap, alert_
 
     # verify that the caps where created properly
     #  first get the alert for the cap
-    alert_query = select(alert_models.Alerts).where(alert_models.Alerts.alert_description == alert_dict["alert_description"])
+    alert_query = select(alert_models.Alerts).where(
+        alert_models.Alerts.alert_description == alert_dict["alert_description"]
+    )
     LOGGER.debug(f"alert_query: {alert_query}")
     alert_records = session.exec(alert_query).all()
 
-    # identify the alert with with the largest id to indicate the last one 
+    # identify the alert with with the largest id to indicate the last one
     # created
     alert_record = None
     for cur_alert in alert_records:
@@ -50,11 +53,13 @@ def test_get_caps(db_with_alert: Session, test_client_with_alert_and_cap, alert_
     for cap in cap_dict:
         # if the alert_id isn't the one that has been created for this test don't
         # skip over those caps
-        if cap['alert_id'] == alert_id_to_verify:
+        if cap["alert_id"] == alert_id_to_verify:
             # get the alert that corresponds with the cap
-            alert_query = select(alert_models.Alerts).where(alert_models.Alerts.alert_id == cap["alert_id"])
+            alert_query = select(alert_models.Alerts).where(
+                alert_models.Alerts.alert_id == cap["alert_id"]
+            )
             alert_record = session.exec(alert_query).all()[-1]
-            assert cap['alert_id'] == alert_record.alert_id
+            assert cap["alert_id"] == alert_record.alert_id
             LOGGER.debug(f"cap alert area id: {cap['alert_id']}")
 
             # now extract the alert levels / alert basins from the alert to verify against
@@ -63,12 +68,28 @@ def test_get_caps(db_with_alert: Session, test_client_with_alert_and_cap, alert_
             for alert_link in alert_record.alert_links:
                 if alert_link.alert_level.alert_level not in alert_lvl_basins_dict:
                     alert_lvl_basins_dict[alert_link.alert_level.alert_level] = []
-                alert_lvl_basins_dict[alert_link.alert_level.alert_level].append(alert_link.basin.basin_name)
+                alert_lvl_basins_dict[alert_link.alert_level.alert_level].append(
+                    alert_link.basin.basin_name
+                )
             LOGGER.debug(f"alert_lvl_basins_dict: {alert_lvl_basins_dict}")
 
             # verify the alert level is in the alert
-            assert cap['alert_level']['alert_level'] in alert_lvl_basins_dict
+            assert cap["alert_level"]["alert_level"] in alert_lvl_basins_dict
             # verify the basins
-            for event_area in cap['event_areas']:
+            for event_area in cap["event_areas"]:
                 LOGGER.debug(f"current event_area: {event_area}")
-                assert event_area['cap_area_basin']['basin_name'] in alert_lvl_basins_dict[cap['alert_level']['alert_level']]
+                assert (
+                    event_area["cap_area_basin"]["basin_name"]
+                    in alert_lvl_basins_dict[cap["alert_level"]["alert_level"]]
+                )
+
+
+def test_alert_cancel():
+    """
+    This test will run through various scenarios where the status of an alert
+    is changed from 'active' to 'cancel'
+
+    The test will verify that when this takes place any caps that have been
+    created for the alert are set to cancelled as well
+    """
+    pass

--- a/backend/test/db_tests/test_db_alerts.py
+++ b/backend/test/db_tests/test_db_alerts.py
@@ -8,7 +8,7 @@ from helpers.alert_helpers import (
     create_fake_alert,
 )
 from sqlmodel import Session, select
-from src.types import AlertAreaLevel
+from src.types import AlertAreaLevel, AlertDataDict
 from src.v1.crud import crud_alerts
 from src.v1.models import alerts as alerts_models
 from src.v1.models import basins as basins_model
@@ -370,11 +370,23 @@ def test_add_new_alert_links(db_test_connection, alert_dict, alert_basin_write):
         ],
     ],
 )
-def test_alert_history(db_test_connection, existing_alert_list):
+def test_alert_history(
+    db_test_connection: Session, existing_alert_list: List[AlertDataDict]
+):
+    """
+    creates a fake alert, then creates a history record from it, and then
+    verifies that the alert history record that was written to the database contains
+    the same data as the original data that was used to create it.
+
+    :param db_test_connection: input database session
+    :type db_test_connection: Session
+    :param existing_alert_list: a list of AlertDataDict dictionaries that are used
+        to create a fake alert record, and then record the record in the the alert
+        history table.
+    :type existing_alert_list: AlertDataDict
+    """
     session = db_test_connection
 
-    fake_alert = create_fake_alert(existing_alert_list)
-    LOGGER.debug(f"fake_alert: {fake_alert}")
     input_alert = create_fake_alert(existing_alert_list)
     input_alert_db = crud_alerts.create_alert(session=session, alert=input_alert)
 

--- a/backend/test/db_tests/test_db_cap.py
+++ b/backend/test/db_tests/test_db_cap.py
@@ -601,12 +601,14 @@ def test_cancel_cap_for_alert(
     """
     _summary_
 
-    :param db_test_connection: _description_
-    :type db_test_connection: _type_
-    :param existing_alert_list: _description_
-    :type existing_alert_list: _type_
-    :param updated_alert_list: _description_
-    :type updated_alert_list: _type_
+    :param db_test_connection: a database session
+    :type db_test_connection: Session
+    :param existing_alert_list: A list of AlertDataDict struct that provide the 
+        alert level and associated basins to create
+    :type existing_alert_list: List[AlertDataDict]
+    :param updated_alert_list: same as above except this list describes how the 
+        alert should be updated
+    :type updated_alert_list: List[AlertDataDict]
     """
     session = db_test_connection
     test_setup_dict = pre_test_setup(

--- a/backend/test/db_tests/test_db_cap.py
+++ b/backend/test/db_tests/test_db_cap.py
@@ -4,6 +4,7 @@ import typing
 import pytest
 from helpers.alert_helpers import create_fake_alert, update_fake_alert
 from sqlmodel import Session, select
+from src.types import AlertDataDict
 from src.v1.crud import crud_alerts, crud_cap
 from src.v1.models import alerts as alerts_models
 from src.v1.models import basins as basin_models
@@ -209,7 +210,9 @@ def test_edit_alert_cap_events(db_with_alert_and_caps):
     ],
 )
 def test_record_cap_event_history(
-    db_test_connection, input_alert_list, updated_alert_list
+    db_test_connection: Session,
+    input_alert_list: typing.List[AlertDataDict],
+    updated_alert_list: typing.List[AlertDataDict],
 ):
     session = db_test_connection
 
@@ -316,7 +319,11 @@ def test_record_cap_event_history(
         ],
     ],
 )
-def test_new_cap_for_alert(db_test_connection, existing_alert_list, updated_alert_list):
+def test_new_cap_for_alert(
+    db_test_connection: Session,
+    existing_alert_list: typing.List[AlertDataDict],
+    updated_alert_list: typing.List[AlertDataDict],
+):
     """
     _summary_
 
@@ -457,7 +464,9 @@ def test_new_cap_for_alert(db_test_connection, existing_alert_list, updated_aler
     ],
 )
 def test_update_cap_for_alert(
-    db_test_connection, existing_alert_list, updated_alert_list
+    db_test_connection: Session,
+    existing_alert_list: typing.List[AlertDataDict],
+    updated_alert_list: typing.List[AlertDataDict],
 ):
     session = db_test_connection
 
@@ -585,7 +594,9 @@ def test_update_cap_for_alert(
     ],
 )
 def test_cancel_cap_for_alert(
-    db_test_connection, existing_alert_list, cancel_alert_list
+    db_test_connection,
+    existing_alert_list: typing.List[AlertDataDict],
+    cancel_alert_list: typing.List[AlertDataDict],
 ):
     """
     _summary_
@@ -684,7 +695,9 @@ def test_cancel_cap_for_alert(
         ],
     ],
 )
-def test_alert_cancelled(db_test_connection, existing_alert_list):
+def test_alert_cancelled(
+    db_test_connection, existing_alert_list: typing.List[AlertDataDict]
+):
     """
     This test will cancel an alert and then call 'update_caps' method and verify
     that the related caps have been cancelled
@@ -729,6 +742,7 @@ def test_alert_cancelled(db_test_connection, existing_alert_list):
 
 # Utility Methods to help with setting up test conditions
 # ---------------------------------------------------------------------------
+# TODO: move these to a helper or utility module
 
 
 def get_alert_level_dict(session: Session):

--- a/backend/test/helpers/alert_helpers.py
+++ b/backend/test/helpers/alert_helpers.py
@@ -3,15 +3,11 @@ import logging
 import typing
 
 import faker
+from src.types import AlertDataDict
 from src.v1.models import alerts as alerts_models
 from src.v1.models import basins as basin_models
 
 LOGGER = logging.getLogger(__name__)
-
-
-AlertDataDict = typing.TypedDict(
-    "AlertDataDict", {"alert_level": str, "basin_names": typing.List[str]}
-)
 
 
 def create_alertlvl_basin_dict(
@@ -78,7 +74,7 @@ def create_fake_alert(alert_list: AlertDataDict) -> alerts_models.Alert_Basins_W
         alert_hydro_conditions=hydro_cond,
         alert_meteorological_conditions=met_cond,
         author_name=auth,
-        alert_status="active",
+        alert_status=alerts_models.AlertStatus.active.value,
         alert_created=datetime.datetime.now(datetime.timezone.utc),
         alert_updated=datetime.datetime.now(datetime.timezone.utc),
         alert_links=alert_area_list,
@@ -132,5 +128,3 @@ def create_update_model(alert_list: AlertDataDict) -> alerts_models.Alert_Basins
         alert_links=alert_area_list,
     )
     return out_data
-
-

--- a/backend/test/helpers/db_helpers.py
+++ b/backend/test/helpers/db_helpers.py
@@ -45,14 +45,21 @@ class db_cleanup:
         alert_areas = self.session.exec(alert_area_query).all()
         for alert_area in alert_areas:
             self.session.delete(alert_area)
+            self.session.delete(alert_area.alert)
+        self.session.flush()
 
-        # get the alert records that relate to the alert id
+        # The code above should delete the alert and the alert area records
+        # Below is a check to make sure that the alert records are deleted
         alerts_query = select(alerts_models.Alerts).where(
             alerts_models.Alerts.alert_id == alert_id
         )
         alerts = self.session.exec(alerts_query).all()
         for alert in alerts:
             LOGGER.info(f"Deleting alert record for alert id: {alert.alert_id}")
+            alert.alert_links = []
+            self.session.add(alert)
+            self.session.refresh(alert)
+
             self.session.delete(alert)
         self.session.flush()
 

--- a/backend/test/helpers/db_helpers.py
+++ b/backend/test/helpers/db_helpers.py
@@ -21,8 +21,8 @@ class db_cleanup:
         :param alert_id: the alert id that needs to be cleaned from the database
         :type alert_id: int
         """
-        self.delete_cap_events(alert_id=alert_id)
         self.delete_cap_event_history(alert_id=alert_id)
+        self.delete_cap_events(alert_id=alert_id)
         self.delete_alert_history(alert_id=alert_id)
         self.delete_alerts(alert_id=alert_id)
 
@@ -116,6 +116,7 @@ class db_cleanup:
             for cap_area in cap_areas:
                 self.session.delete(cap_area)
             self.session.delete(cap)
+            self.session.flush()
 
         self.session.flush()
 

--- a/docs/backend-planning/data_flow.md
+++ b/docs/backend-planning/data_flow.md
@@ -96,7 +96,7 @@ block-beta
   new_alert --> cap_event_2
 ```
 
-### Advisory Edited - Alert Level Changed 3
+### Advisory Edited - Alert Level Changed 3 (area alert level change / move)
 
 In the Alert, the basin ***Nechako*** is being upgrade from ***Flood Watch*** to 
 ***Flood Warning***.  A new CAP_EVENT will be generated for the alert level 
@@ -106,18 +106,20 @@ In the Alert, the basin ***Nechako*** is being upgrade from ***Flood Watch*** to
 block-beta
   columns 3
   space
-  new_alert("ALERT EDITED\nalert-id: 1\n----Basins / Alert Levels----\n- Fraser / High Streamflow\n- Upper Fraser / Flood Warning\n- Nechako / Flood Watch\n")
+  new_alert("ALERT EDITED\nalert-id: 1\n----Basins / Alert Levels----\n- Fraser / High Streamflow\n- Upper Fraser / Flood Watch\n- Nechako / Flood Warning\n")
   space
   space:3
   cap_event_1("CAP EVENT - UPDATED\ncap-event-id: 10\ncap-event-status: UPDATE\nbasins:'Fraser'\nalert_level:'High Streamflow'")
-  cap_event_2("CAP EVENT UPDATED\ncap-event-id: 11\ncap-event-status: UPDATE\nbasin:'Upper Fraser'\nalert_level:'Flood Warning'")
-  cap_event_3("CAP EVENT CREATED\ncap-event-id: 12\ncap-event-status: ALERT\nbasin: 'Nechako'\nalert_level:'Flood Watch'")
+  cap_event_2("CAP EVENT UPDATED\ncap-event-id: 11\ncap-event-status: UPDATE\nbasin:'Upper Fraser'\nalert_level:'Flood Watch'")
+  cap_event_3("CAP EVENT CREATED\ncap-event-id: 12\ncap-event-status: ALERT\nbasin: 'Nechako'\nalert_level:'Flood Warning'")
 
   new_alert --> cap_event_1
   new_alert --> cap_event_2
   new_alert --> cap_event_3
 
 ```
+
+* *An Alert object can only ever have three different caps associated with it, one for each of the different alert levels*
 
 ### Advisory Edited - Basin Removed 1
 
@@ -148,6 +150,8 @@ block-beta
   new_alert --> cap_event_3
 
 ```
+
+* *the cancelled CAP event will show the previous attributes associated with the CAP, prior to the cancel*
 
 ### Advisory Edited - Basin Removed 2
 
@@ -215,14 +219,43 @@ block-beta
   space
   space:3
   cap_event_1("CAP EVENT - UPDATE\ncap-event-id: 10\ncap-event-status: UPDATE\nbasins:'Middle Fraser', 'South Thompson'\nalert_level:'High Streamflow'")
-  cap_event_2("CAP EVENT - UPDATE\ncap-event-id: 11\ncap-event-status: UPDATE\nbasin:'Upper Fraser'\nalert_level:'Flood Watch'")
-  cap_event_3("CAP EVENT - ALERT\ncap-event-id: 13\ncap-event-status: ALERT\nbasin: 'Upper Fraser'\nalert_level:'Flood Warning'")
+  cap_event_2("CAP EVENT - UPDATE\ncap-event-id: 11\ncap-event-status: UPDATE\nbasin:'Upper Fraser'\nalert_level:'Flood Warning'")
+  cap_event_3("CAP EVENT - ALERT (unmodified)\ncap-event-id: 13\ncap-event-status: ALERT\nbasin: 'Upper Fraser'\nalert_level:'Flood Watch'")
 
   original_alert --> new_alert
   new_alert --> cap_event_1
   new_alert --> cap_event_2
   new_alert --> cap_event_3
 ```
+
+### Alert / Advisory is cancelled
+
+ALERT objects have a status set to either 'ACTIVE' or 'CANCELLED'.  If the 'Alert'
+is set to 'CANCELLED, then all the CAP Events that are associated with an Alert
+will be have their `cap-event-status` set to `CANCEL`
+
+
+```mermaid
+block-beta
+  columns 3
+  space
+  original_alert("ORIGINAL ALERT\nalert-id: 1\n----Basins / Alert Levels----\n-Fraser / High Streamflow\n-Upper Fraser / Flood Watch")
+  space:5
+  new_alert("ALERT CANCELLED\nalert-id: 1\n----Basins / Alert Levels----\n - Fraser / Flood Watch\n - Upper Fraser / Flood Warning\n - Middle Fraser / High Streamflow\n - South Thompson / High Streamflow")
+  space
+  space:3
+  cap_event_1("CAP EVENT - CANCEL\ncap-event-id: 10\ncap-event-status: CANCEL\nbasins:'Middle Fraser', 'South Thompson'\nalert_level:'High Streamflow'")
+  cap_event_2("CAP EVENT - CANCEL\ncap-event-id: 11\ncap-event-status: CANCEL\nbasin:'Upper Fraser'\nalert_level:'Flood Warning'")
+  cap_event_3("CAP EVENT - CANCEL (unmodified)\ncap-event-id: 13\ncap-event-status: CANCEL\nbasin: 'Upper Fraser'\nalert_level:'Flood Watch'")
+
+  original_alert --> new_alert
+  new_alert --> cap_event_1
+  new_alert --> cap_event_2
+  new_alert --> cap_event_3
+```
+
+When an 'Alert' gets cancelled, the CAP attributes are all left unchanged, and 
+only the `cap-event-status` attribute is updated to `cancel`
 
 ## Data Flow Summary
 


### PR DESCRIPTION
Related to issue: #113 

# Description

Modified update of alert so that when an existing alert is set to 'cancel' all the associated cap events are also cancelled.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Add docs in the flow diagram that illustrate how this will work 

# How Has This Been Tested?

Created two new test that test this functionality at the database level as well as at the api level
- [x] tests that update_cap_event will cancel any all the cap events if the associated alert is cancelled 
- [ ] test that verifies that updating the status of an existing alert through the api results in all the associated cap events being cancelled.


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged





---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-rfc-alertauthoring-116-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-rfc-alertauthoring-116-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-rfc-alertauthoring/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-rfc-alertauthoring/actions/workflows/merge.yml)