### PR TITLE
feat: 110 capture cap history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ frontend/hydro_alerting/junk.js
 junk/
 frontend/hydro_alerting/Caddyfile_mine
 frontend/hydro_alerting/Caddyfile_mine2
+test_db.db-journal

--- a/backend/src/types.py
+++ b/backend/src/types.py
@@ -2,9 +2,10 @@ import typing
 
 from typing_extensions import TypedDict
 
+# The data model used for RFC alerts
 AlertAreaLevel = TypedDict("AlertAreaLevel", {"basin": str, "alert_level": int})
 
-
+# the data model used to describe data used to create caps
 AlertDataDict = typing.TypedDict(
     "AlertDataDict", {"alert_level": str, "basin_names": typing.List[str]}
 )

--- a/backend/src/v1/crud/crud_alerts.py
+++ b/backend/src/v1/crud/crud_alerts.py
@@ -271,7 +271,7 @@ def update_alert(
         #       to fail, then verify that it did not get written to the database
         LOGGER.debug("not the same!")
 
-        # now update the alert record
+        # update the alert record...
         attributes_to_update = [
             "alert_description",
             "alert_hydro_conditions",
@@ -279,7 +279,7 @@ def update_alert(
             "author_name",
             "alert_status",
         ]
-        # update core attributes if different
+        # update core attributes if they are different
         for atrib in attributes_to_update:
             update_value = getattr(updated_alert, atrib)
             if getattr(current_alert, atrib) != update_value:
@@ -287,15 +287,17 @@ def update_alert(
                 setattr(current_alert, atrib, update_value)
                 session.add(current_alert)
                 session.flush()
-        # Dealing with the related basin / alert levels
-        # -- get the alert areas / levels incomming
+
+        # update the basins and alert levels
+        #   determining what needs to be updated
+        #   -- get the alert areas / levels incomming
         basin_levels_incomming = []
         for alert_link in updated_alert.alert_links:
             basin_levels_incomming.append(
                 [alert_link.basin.basin_name, alert_link.alert_level.alert_level]
             )
 
-        # -- remove the alert areas that are not in the incomming alert but are in existing
+        #   -- remove the alert areas that are not in the incomming alert but are in existing
         basin_levels_existing = []
         for alert_link in current_alert.alert_links:
             cur_bas_lvl = [
@@ -310,7 +312,8 @@ def update_alert(
                 session.delete(alert_link)
                 session.flush()  # have to flush or won't update the orm relationship
         session.refresh(current_alert)
-        # determine what needs to be added
+
+        # determine alert levels / basins that need to be added to the alert
         alert_area_to_add = []
         for alert_link in updated_alert.alert_links:
             cur_bas_lvl = [
@@ -324,9 +327,9 @@ def update_alert(
                     + f"{alert_link.basin.basin_name} {alert_link.alert_level.alert_level}"
                 )
                 alert_area_to_add.append(cur_bas_lvl)
-            # elif cur_bas_lvl not in basin_levels_incomming
 
-        # add alert areas that are in incomming but not in existing.
+        # Having determined what needs to be added to the alert, doing the actual
+        # add in the database
         for alert_link in alert_area_to_add:
             basin_name = alert_link[0]
             alert_level = alert_link[1]
@@ -339,8 +342,8 @@ def update_alert(
             current_alert.alert_links.append(alert_area)
             session.refresh(current_alert)
 
+        # update the last updated timestamp
         current_alert.alert_updated = datetime.datetime.now(datetime.timezone.utc)
-        # ---- Alert record update complete
 
     LOGGER.debug(f"current alert before send: {current_alert}")
     return current_alert

--- a/backend/src/v1/crud/crud_alerts.py
+++ b/backend/src/v1/crud/crud_alerts.py
@@ -340,6 +340,7 @@ def update_alert(
                 alert=current_alert,
             )
             current_alert.alert_links.append(alert_area)
+            session.flush()
             session.refresh(current_alert)
 
         # update the last updated timestamp
@@ -369,7 +370,7 @@ def create_area_alert_record(
         basin_sql = select(basins_model.Basins).where(
             basins_model.Basins.basin_name == basin_name
         )
-        basin_similk = session.exec(basin_sql).first()
+        basin_data = session.exec(basin_sql).first()
 
         alert_lvl_sql = select(alerts_models.Alert_Levels).where(
             alerts_models.Alert_Levels.alert_level == alert_level
@@ -377,13 +378,13 @@ def create_area_alert_record(
         alert_lvl = session.exec(alert_lvl_sql).first()
 
         alert_area = alerts_models.Alert_Areas(
-            alert_level=alert_lvl, basin=basin_similk, alert=alert
+            alert_level=alert_lvl, basin=basin_data, alert=alert
         )
     else:
-        basin_similk = basins_model.BasinBase(basin_name=basin_name)
+        basin_data = basins_model.BasinBase(basin_name=basin_name)
         alert_lvl = alerts_models.Alert_Levels_Base(alert_level=alert_level)
         alert_area = alerts_models.Alert_Areas_Write(
-            alert_level=alert_lvl, basin=basin_similk
+            alert_level=alert_lvl, basin=basin_data
         )
     return alert_area
 

--- a/backend/src/v1/crud/crud_cap.py
+++ b/backend/src/v1/crud/crud_cap.py
@@ -40,7 +40,9 @@ def get_cap_event_status(session: Session, status: str) -> cap_models.Cap_Event_
     return cap_status_create_record
 
 
-def create_cap_event(session: Session, alert: alerts_models.Alerts):
+def create_cap_event(
+    session: Session, alert: alerts_models.Alerts
+) -> List[cap_models.Cap_Event]:
     """
     The alert that will be generated in the database  is recieved as a parameter.
     The method will extract out the alert areas / basins and the alert_levels from the alert

--- a/backend/src/v1/crud/crud_cap.py
+++ b/backend/src/v1/crud/crud_cap.py
@@ -220,8 +220,9 @@ def update_cap_for_alert(
     session: Session, alert: alerts_models.Alerts, cap_comps: cap_models.Cap_Comparison
 ):
     """
-    This method will modify existing alerts who's associated basins have been
-    modified.
+    This method will modify existing caps who's associated basins have been
+    modified.  This method will use the cap comparison object to determine
+    what has changed and only update things that have changed.
 
     :param session: input database transaction / session
     :type session: Session

--- a/backend/src/v1/crud/crud_cap.py
+++ b/backend/src/v1/crud/crud_cap.py
@@ -138,7 +138,6 @@ def update_cap_event(session: Session, alert: alerts_models.Alerts):
 
     # only write history records if there are changes
     if creates or updates or cancels:
-        record_history(session, alert)
 
         LOGGER.debug(f"creates: {creates}")
         LOGGER.debug(f"updates: {updates}")
@@ -411,6 +410,7 @@ def __write_history_for_cap_comp(
         cur_cap_event = __get_cap_event(caps_for_alert, update.alert_level.alert_level)
 
         # creating the history record
+        # TODO: Should only update
         cap_event_history = cap_models.Cap_Event_History(
             alert_id=alert_id,
             cap_event_id=cur_cap_event.cap_event_id,
@@ -485,9 +485,8 @@ class CapCompare:
         :param alert: input alert object containing the new alert state.
         :type alert:
         """
-        levels = (
-            {}
-        )  # used to keep track of which events are associated with what alert level
+        levels = {}
+        # used to keep track of which events are associated with what alert level
         for alert_level_area in self.alert.alert_links:
             # basin = alert_level_area.basin
             LOGGER.debug(f"alert_level_area: {alert_level_area}")
@@ -511,7 +510,7 @@ class CapCompare:
             else:
                 levels[current_level_str].basins.append(basinBase)
         LOGGER.debug(f"levels: {levels}")
-        self.new_alert_cap_comp = levels.values()
+        self.new_alert_cap_comp = list(levels.values())
 
     def generate_existing_cap_comp_from_alert(self) -> List[cap_models.Cap_Comparison]:
         """
@@ -543,7 +542,7 @@ class CapCompare:
                     )
                 else:
                     levels[cap.alert_level.alert_level].basins.append(basinBase)
-        self.existing_alert_cap_comp = levels.values()
+        self.existing_alert_cap_comp = list(levels.values())
 
     def get_delta(self):
         """

--- a/backend/src/v1/routes/alert_routes.py
+++ b/backend/src/v1/routes/alert_routes.py
@@ -16,6 +16,7 @@ router = APIRouter()
 LOGGER = logging.getLogger(__name__)
 
 
+# get all the alerts
 @router.get("/", response_model=List[alerts_models.Alert_Basins])
 def read_alerts(
     db: Session = Depends(session.get_db), skip: int = 0, limit: int = 100
@@ -33,6 +34,7 @@ def read_alerts(
     return alerts
 
 
+# get a specific alert
 @router.get("/{alert_id}", response_model=alerts_models.Alert_Basins)
 def read_alert(
     alert_id: int,
@@ -50,6 +52,7 @@ def read_alert(
     return alert
 
 
+# create an alert
 @router.post(
     "/",
     status_code=201,
@@ -66,10 +69,11 @@ def create_alert(
     caps = crud_cap.create_cap_event(session=session, alert=written_alert)
     # not doing anything with the caps at this point
     LOGGER.debug(f"cap created from the alert: {caps}")
-    session.commit()
+    # session.commit()
     return written_alert
 
 
+# update an alert
 @router.patch(
     "/{alert_id}" + "/",
     response_model=alerts_models.Alert_Basins,
@@ -119,6 +123,7 @@ def update_alert(
     LOGGER.debug(f"token: {token}")
     updated_alert.author_name = token["display_name"]
     session.add(updated_alert)
+    session.flush()
 
     # record the current state of the cap events that are relted to the alert that
     # is being updated.

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -214,6 +214,7 @@ def test_app_with_auth(db_test_connection, mock_access_token):
 
     def get_db() -> Generator[sqlmodel.Session, None, None]:
         yield db_test_connection
+        db_test_connection.commit()
 
     def authorize() -> Generator[bool, None, None]:
         LOGGER.debug("override the authroizations")

--- a/backend/test/helpers/alert_helpers.py
+++ b/backend/test/helpers/alert_helpers.py
@@ -1,5 +1,8 @@
 import datetime
+import json
 import logging
+import os
+import random
 import typing
 
 import faker
@@ -34,20 +37,23 @@ def create_alertlvl_basin_dict(
 
 
 def create_alert_area_list(
-    alert_list: AlertDataDict,
+    alert_list: typing.List[AlertDataDict],
 ) -> typing.List[alerts_models.Alert_Areas_Write]:
     LOGGER.debug(f"alert_dict: {alert_list}")
     alert_area_list = []
     for alert_dict in alert_list:
-        for basin_name in alert_dict["basin_names"]:
-            LOGGER.debug(f"basin_name: {basin_name}")
-            alert_area = alerts_models.Alert_Areas_Write(
-                alert_level=alerts_models.Alert_Levels_Base(
-                    alert_level=alert_dict["alert_level"]
-                ),
-                basin=basin_models.BasinBase(basin_name=basin_name),
-            )
-            alert_area_list.append(alert_area)
+        # it is possible to remove all areas associated with an alert
+        # which will ultimately cancel the alert
+        if alert_dict["basin_names"]:
+            for basin_name in alert_dict["basin_names"]:
+                LOGGER.debug(f"basin_name: {basin_name}")
+                alert_area = alerts_models.Alert_Areas_Write(
+                    alert_level=alerts_models.Alert_Levels_Base(
+                        alert_level=alert_dict["alert_level"]
+                    ),
+                    basin=basin_models.BasinBase(basin_name=basin_name),
+                )
+                alert_area_list.append(alert_area)
     return alert_area_list
 
 
@@ -83,8 +89,115 @@ def create_fake_alert(alert_list: AlertDataDict) -> alerts_models.Alert_Basins_W
     return alert
 
 
+def update_random_alert_data_dict(
+    alert_list: typing.List[AlertDataDict], update=False
+) -> typing.List[AlertDataDict]:
+    """
+    randomly updates the alert_list
+
+    :param alert_list: _description_
+    :type alert_list: _type_
+    """
+    all_basins = get_basin_data(just_basins=True)
+    alert_lvls = get_alert_level_data(just_alerts=True)
+
+    alert_data_list = []
+    num_alerts = random.randint(1, len(alert_lvls))
+
+    used_alert_lvls = []
+    used_basins = []
+
+    for alert_index in range(num_alerts):
+        if alert_index < len(alert_list):
+            # the alert exists
+            alert_lvl = alert_list[alert_index]["alert_level"]
+            used_alert_lvls.append(alert_lvl)
+            num_basins = random.randint(1, 5)
+
+            if num_basins > len(alert_list[alert_index]["basin_names"]):
+                # we need to add __ number of basins
+                avail_basins_set = (
+                    set(all_basins)
+                    - set(alert_list[alert_index]["basin_names"])
+                    - set(used_basins)
+                )
+
+                avail_basins = list(avail_basins_set)
+
+                new_basins = random.choices(
+                    avail_basins,
+                    k=num_basins - len(alert_list[alert_index]["basin_names"]),
+                )
+                basins = alert_list[alert_index]["basin_names"][0:]
+                basins = basins.extend(new_basins)
+                used_basins.extend(new_basins)
+
+            elif num_basins < len(alert_list[alert_index]["basin_names"]):
+                # need to randomly remove basins
+                basins = random.choices(
+                    alert_list[alert_index]["basin_names"], k=num_basins
+                )
+            elif num_basins == len(alert_list[alert_index]["basin_names"]):
+                basins = alert_list[alert_index]["basin_names"]
+            if basins is None:
+                basins = []
+            alert_dict = {"alert_level": alert_lvl, "basin_names": basins}
+            alert_data_list.append(alert_dict)
+        else:
+            # the alert level does not exist
+            avail_alerts = list(set(alert_lvls) - set(used_alert_lvls))
+            alert_lvl = random.choice(avail_alerts)
+            used_alert_lvls.append(alert_lvl)
+            num_basins = random.randint(1, 5)
+            basins = random.choices(all_basins, k=num_basins)
+            if basins is None:
+                basins = []
+            alert_dict = {"alert_level": alert_lvl, "basin_names": basins}
+            alert_data_list.append(alert_dict)
+
+    # if update is true then at least one of the existing alert levels must
+    # be part of the updated alert list
+    if update:
+        # check to see if the alert level is included in the alert_data_list
+        updated_alert_lvls = [alert["alert_level"] for alert in alert_data_list]
+        original_alert_lvls = [
+            alert["alert_level"]
+            for alert in alert_list
+            if alert["alert_level"] in updated_alert_lvls
+        ]
+        if not original_alert_lvls:
+            # take the first alert level and make it the same as the first alert
+            # level in original_alert_lvls
+            alert_data_list[0]["alert_level"] = alert_list[0]["alert_level"]
+
+    # There MUST be a difference so if none is detected then run again
+    if alert_data_list == alert_list:
+        alert_data_list = update_random_alert_data_dict(alert_list, update=update)
+
+    return alert_data_list
+
+
+def get_random_alert_data_dict() -> typing.List[AlertDataDict]:
+
+    basins = get_basin_data(just_basins=True)
+    alert_lvls = get_alert_level_data(just_alerts=True)
+    LOGGER.debug(f"alert_lvls: {alert_lvls}")
+
+    alert_data_list = []
+    # determines how many alert_level / basin dicts to generate
+    num_alerts = random.randint(1, len(alert_lvls))
+
+    for _ in range(num_alerts):
+        alert_lvl = random.choice(alert_lvls)
+        num_basins = random.randint(1, 5)
+        basins = random.choices(basins, k=num_basins)
+        alert_dict = {"alert_level": alert_lvl, "basin_names": basins}
+        alert_data_list.append(alert_dict)
+    return alert_data_list
+
+
 def update_fake_alert(
-    existing_alert: alerts_models.Alerts, alert_list: AlertDataDict
+    existing_alert: alerts_models.Alerts, alert_list: typing.List[AlertDataDict]
 ) -> alerts_models.Alert_Basins_Write:
     """
     used to simulate the condition where an alert has been updated and now the
@@ -106,8 +219,8 @@ def update_fake_alert(
         alert_meteorological_conditions=existing_alert.alert_meteorological_conditions,
         author_name=auth,
         alert_status=existing_alert.alert_status,
-        alert_created=existing_alert.alert_created,
-        alert_updated=datetime.datetime.now(datetime.timezone.utc),
+        # alert_created=existing_alert.alert_created,
+        # alert_updated=datetime.datetime.now(datetime.timezone.utc),
         alert_links=alert_area_list,
     )
     return updated_alert
@@ -128,3 +241,48 @@ def create_update_model(alert_list: AlertDataDict) -> alerts_models.Alert_Basins
         alert_links=alert_area_list,
     )
     return out_data
+
+
+def get_basin_data(just_basins: bool = False):
+    basin_data_file_path = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "alembic",
+            "data",
+            "basins.json",
+        )
+    )
+    LOGGER.debug(f"basin data path: {basin_data_file_path}")
+    with open(basin_data_file_path, "r") as basin_data_file:
+        basin_data = json.load(basin_data_file)
+    LOGGER.debug(f"number of basins: {len(basin_data)}")
+    if just_basins:
+        basin_list = [basin_record["basin_name"] for basin_record in basin_data]
+
+        LOGGER.debug(f"basin_list length: {len(basin_list)}")
+        return basin_list
+    return basin_data
+
+
+def get_alert_level_data(just_alerts: bool = False):
+    alert_lvl_file_path = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "alembic",
+            "data",
+            "alert_levels.json",
+        )
+    )
+    LOGGER.debug(f"alert_lvl_file_path: {alert_lvl_file_path}")
+
+    with open(alert_lvl_file_path, "r") as alert_lvl_file:
+        alert_lvl_data = json.load(alert_lvl_file)
+
+    if just_alerts:
+        alert_list = [alert_record["alert_level"] for alert_record in alert_lvl_data]
+        return alert_list
+    return alert_lvl_data

--- a/backend/test/helpers/alert_helpers.py
+++ b/backend/test/helpers/alert_helpers.py
@@ -6,7 +6,7 @@ import random
 import typing
 
 import faker
-from src.types import AlertDataDict
+from src.types import AlertAreaLevel, AlertDataDict
 from src.v1.models import alerts as alerts_models
 from src.v1.models import basins as basin_models
 
@@ -57,7 +57,9 @@ def create_alert_area_list(
     return alert_area_list
 
 
-def create_fake_alert(alert_list: AlertDataDict) -> alerts_models.Alert_Basins_Write:
+def create_fake_alert(
+    alert_list: typing.List[AlertDataDict],
+) -> alerts_models.Alert_Basins_Write:
     """
     creates a fake alert object from a dictionary.  The dictionary is expected
     to contain the following keys:
@@ -87,6 +89,35 @@ def create_fake_alert(alert_list: AlertDataDict) -> alerts_models.Alert_Basins_W
     )
     LOGGER.debug(f"fake alert: {alert}")
     return alert
+
+
+def AlertAreaLevel_to_AlertDataDict(
+    input_alert_area_levels: typing.List[AlertAreaLevel],
+) -> typing.List[AlertDataDict]:
+    """
+    in order to accomodate older tests that used the AlertAreaLevel data model to
+    define the alert areas, and alert levels for test conditions, this function
+    will convert from the AlertAreaLevel data model to the Alert_Areas_Write data
+    to allow other methods in this library to be used to parameterize testing.
+
+    :param input_alert_area_levels: a list of AlertAreaLevel data models to be converted
+        to Alert_Areas_Write models
+    :type input_alert_area_levels: typing.List[AlertAreaLevel]
+    :return: _description_
+    :rtype: typing.List[alerts_models.Alert_Areas_Write]
+    """
+    tmp_dict = {}
+    for alert_area_level in input_alert_area_levels:
+        if alert_area_level["alert_level"] not in tmp_dict:
+            tmp_dict[alert_area_level["alert_level"]] = {
+                "alert_level": alert_area_level["alert_level"],
+                "basin_names": [alert_area_level["basin"]],
+            }
+        else:
+            tmp_dict[alert_area_level["alert_level"]]["basin_names"].append(
+                alert_area_level["basin"]
+            )
+    return list(tmp_dict.values())
 
 
 def update_random_alert_data_dict(

--- a/backend/test/helpers/db_helpers.py
+++ b/backend/test/helpers/db_helpers.py
@@ -11,6 +11,7 @@ class db_cleanup:
 
     def __init__(self, session):
         self.session = session
+        self.session.rollback()
 
     def cleanup(self, alert_id: int):
         """


### PR DESCRIPTION
# capture changes to cap events in history table

added code to capture the status of cap events in a history table.  Tests also created to verify it is doing what it is suppose to do.

Fixes # 110

## feat

Please delete options that are not relevant.

- [ ] This change requires a documentation update

# Tests have been created in the pytest framework



## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

For documentation, thinking that should have some documentation that describes the database methods, what they do and when and in what order they should be called when an end point is called.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-rfc-alertauthoring-119-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-rfc-alertauthoring-119-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-rfc-alertauthoring/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-rfc-alertauthoring/actions/workflows/merge.yml)