### PR TITLE
fix: required swapping out form values to api parameters

### DIFF
--- a/frontend/hydro_alerting/src/app/alerts/create-alert/create-alert.component.ts
+++ b/frontend/hydro_alerting/src/app/alerts/create-alert/create-alert.component.ts
@@ -75,8 +75,8 @@ export class CreateAlertComponent implements OnInit {
     let new_alert: AlertCreate = {
       alert_description: this.create_alert_form.value.alert_description,
       alert_status: this.create_alert_form.value.alert_status,
-      alert_hydro_conditions: this.create_alert_form.value.meteorologicalDataEditor,
-      alert_meteorological_conditions: this.create_alert_form.value.hydrologicalDataEditor,
+      alert_hydro_conditions: this.create_alert_form.value.hydrologicalDataEditor,
+      alert_meteorological_conditions: this.create_alert_form.value.meteorologicalDataEditor,
       alert_links: basinAlertLevelData,
       // should get this from the id token
       author_name: this.authzService.payload.display_name


### PR DESCRIPTION
When creating a new alert the text for hydrological conditions was going into the meteorological conditions.  Small typo fix.  


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-rfc-alertauthoring-122-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-rfc-alertauthoring-122-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-rfc-alertauthoring/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-rfc-alertauthoring/actions/workflows/merge.yml)